### PR TITLE
Very quick and dirty async implementation for report processing

### DIFF
--- a/masu/__init__.py
+++ b/masu/__init__.py
@@ -67,8 +67,8 @@ def create_app(test_config=None):
     db = SQLAlchemy(app)  # noqa: F841
 
     # Celery task queue
-    queue = create_celery(app)
-    queue.autodiscover_tasks()
+    celery = create_celery(app)
+    celery.autodiscover_tasks()
 
     # Routes
     app.add_url_rule('/api/v1/status/', view_func=StatusView.as_view('show_status'))

--- a/masu/api/download.py
+++ b/masu/api/download.py
@@ -34,13 +34,17 @@ class DownloadView(View):
     def dispatch_request(self):
         """Packages response for class-based view."""
         orchestrator = Orchestrator()
-        files = orchestrator.prepare_curs()
-        orchestrator.process_curs()
+        orchestrator.prepare_curs()
+        # orchestrator.process_curs()
 
-        downloaded_results_msg = 'Files downloaded and processed: {}'.format(str(files))
-        logger.info(downloaded_results_msg)
+        # downloaded_results_msg = 'Files downloaded and processed: {}'.format(str(files))
+        # logger.info(downloaded_results_msg)
+
+        # response = {
+        #     'files': files,
+        # }
 
         response = {
-            'files': files,
+            'message': 'Queued report processing tasks.'
         }
         return jsonify(response)

--- a/masu/celery/__init__.py
+++ b/masu/celery/__init__.py
@@ -23,10 +23,17 @@ def create_celery(app):
     """Create Celery app object using the Flask app's settings."""
     celery = Celery(
         app.import_name,
-        backend=app.config.get('CELERY_RESULT_BACKEND'),
         broker=app.config.get('CELERY_BROKER_URL')
     )
     celery.conf.update(app.config)
+
+    # Define queues used for report processing
+    # TODO: Actually get tasks to use their respective queues
+    celery.conf.task_routes = {
+        'processor.tasks.get_report_files': {'queue': 'download'},
+        'processor.tasks.process_report_file': {'queue': 'process'}
+    }
+
 
     # pylint: disable=too-few-public-methods
     class ContextTask(celery.Task):

--- a/masu/celery/tasks.py
+++ b/masu/celery/tasks.py
@@ -16,96 +16,22 @@
 #
 """Celery task definitions."""
 
-# pylint: disable=unused-argument, fixme, unused-import
-# FIXME: temporary module-wide disable until tasks are fully implemented.
-
+import datetime
+import logging
 from unittest import mock
 
+from celery.task import periodic_task
 from celery.utils.log import get_task_logger
 
-from masu import create_app
-from masu.celery import create_celery
-from masu.processor.exceptions import MasuProcessingError, MasuProviderError
+from masu.processor.tasks.download import get_report_files
+from masu.processor.tasks.process import process_report_file
+from masu.processor.orchestrator import Orchestrator
 
-MASU = create_app()
-MASU.app_context().push()
-CELERY = create_celery(MASU)
 LOG = get_task_logger(__name__)
 
 
-@CELERY.task(autoretry_for=(MasuProviderError,),
-             retry_backoff=True)
-def check_update(**kwargs):
-    """
-    Task that checks SNS and/or S3 for updated CUR files.
-
-    A chained Celery task is spawned to download the updated files.
-
-    Args:
-        customer (Customer): The customer object from the database.
-
-    Returns:
-        results (Boolean): Task success/failure
-
-    Raises:
-        MasuProviderError: An error occurred accessing the cloud provider.
-
-    """
-    # TODO: 1. look for new data.
-    # TODO: 2. when Step 1 is True, add a cache_from_s3() task to the queue.
-    return True
-
-
-@CELERY.task(autoretry_for=(MasuProviderError,),
-             retry_backoff=True)
-def cache_from_s3(**kwargs):
-    """
-    Task that downloads CUR from S3.
-
-    The downloaded files are stored in a specified directory for processing.
-    A chained Celery task is spawned to process the downloaded files.
-
-    Args:
-        customer (Customer): The customer object from the database.
-        tmpdir (String): The location to store files downloaded from S3
-
-    Returns:
-        results (Boolean): Task success/failure
-
-    Raises:
-        MasuProviderError: An error occurred accessing the cloud provider.
-
-    """
-    # TODO: 1. download new content (compare E-Tags)
-    # TODO: 2. when download completes, add a process_cost_usage_report() task
-    # TODO:    to the queue.
-    return True
-
-
-@CELERY.task(autoretry_for=(MasuProcessingError,),
-             retry_backoff=True)
-def process_cost_usage_report(**kwargs):
-    """
-    Task that processes CUR files, inserting data into the Koku DB.
-
-    Args:
-        customer (Customer): The customer object from the database.
-        tmpdir (String): The location to store files downloaded from S3
-
-    Returns:
-        results (Boolean): Task success/failure
-
-    Raises:
-        MasuProcessingError: An error occurred accessing the cloud provider.
-
-    """
-    # TODO: 1. Unzip and process each .csv.gz file in processing directory.
-    # TODO: 2. Insert any new data found in Step 1, skipping existing data.
-    return True
-
-
-@CELERY.task(track_started=True)
-def test(args):
-    """Test task. Used only in testing."""
-    LOG.debug(args)
-    return mock.Mock(name=__name__, args=args)
+# TODO: Get periodic test to work
+@periodic_task(run_every=datetime.timedelta(hours=1))
+def check_for_report_updates():
+    orchestrator = Orchestrator()
+    orchestrator.prepare_curs()

--- a/masu/config.py
+++ b/masu/config.py
@@ -61,7 +61,7 @@ class Config(object):
 
     # Celery settings
     CELERY_BROKER_URL = f'amqp://{RABBITMQ_HOST}:{RABBITMQ_PORT}'
-    CELERY_RESULT_BACKEND = f'db+postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}'
+    # CELERY_RESULT_BACKEND = f'db+postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}'
 
     REPORT_PROCESSING_BATCH_SIZE = 10000
 

--- a/masu/processor/orchestrator.py
+++ b/masu/processor/orchestrator.py
@@ -18,8 +18,8 @@
 
 import logging
 
-import masu.processor.tasks.download as download_task
-import masu.processor.tasks.process as process_task
+from masu.processor.tasks.download import get_report_files
+# import masu.processor.tasks.process as process_task
 from masu.external.accounts_accessor import AccountsAccessor
 from masu.processor.cur_process_request import CURProcessRequest
 
@@ -45,7 +45,7 @@ class Orchestrator():
             None
         """
         self._accounts = AccountsAccessor().get_accounts()
-        self._processing_requests = []
+        # self._processing_requests = []
 
     def prepare_curs(self):
         """
@@ -68,31 +68,34 @@ class Orchestrator():
             stmt = 'Download task queued for {}'.format(customer_name)
             LOG.info(stmt)
 
-            reports = download_task.get_report_files(customer_name=customer_name,
-                                                     access_credential=credentials,
-                                                     report_source=source,
-                                                     provider_type=provider)
-            for report_dict in reports:
-                cur_request = CURProcessRequest()
-                cur_request.schema_name = account.get_schema_name()
-                cur_request.report_path = report_dict.get('file')
-                cur_request.compression = report_dict.get('compression')
+            reports = get_report_files.delay(
+                customer_name=customer_name,
+                access_credential=credentials,
+                report_source=source,
+                provider_type=provider,
+                schema_name=account.schema_name
+            )
+            # for report_dict in reports:
+            #     cur_request = CURProcessRequest()
+            #     cur_request.schema_name = account.get_schema_name()
+            #     cur_request.report_path = report_dict.get('file')
+            #     cur_request.compression = report_dict.get('compression')
 
-                self._processing_requests.append(cur_request)
+                # self._processing_requests.append(cur_request)
 
         return reports
 
-    def process_curs(self):
-        """
-        Process downloaded cost usage reports.
+    # def process_curs(self):
+    #     """
+    #     Process downloaded cost usage reports.
 
-        Args:
-            None
+    #     Args:
+    #         None
 
-        Returns:
-            None.
+    #     Returns:
+    #         None.
 
-        """
-        for request in self._processing_requests:
-            LOG.info(str(request))
-            process_task.process_report_file(request)
+    #     """
+    #     for request in self._processing_requests:
+    #         LOG.info(str(request))
+    #         process_task.process_report_file.delay(request)

--- a/masu/processor/tasks/download.py
+++ b/masu/processor/tasks/download.py
@@ -18,15 +18,22 @@
 
 import logging
 
-from masu.external.report_downloader import ReportDownloader, ReportDownloaderError
+from celery import shared_task
+from celery.utils.log import get_task_logger
 
-LOG = logging.getLogger(__name__)
+from masu.external.report_downloader import ReportDownloader
+from masu.processor.cur_process_request import CURProcessRequest
+from masu.processor.tasks.process import process_report_file
+
+LOG = get_task_logger(__name__)
 
 
+@shared_task(name='processor.tasks.download', queue_name='download')
 def get_report_files(customer_name,
                      access_credential,
                      report_source,
                      provider_type,
+                     schema_name,
                      report_name=None):
     """
     Task to download a Cost Usage Report.
@@ -35,12 +42,7 @@ def get_report_files(customer_name,
     what report we should downlad.
 
     Args:
-        customer_name     (String): Name of the customer owning the cost usage report.
-        access_credential (String): Credential needed to access cost usage report
-                                    in the backend provider.
-        report_source     (String): Location of the cost usage report in the backend provider.
-        provider_type     (String): Koku defined provider type string.  Example: Amazon = 'AWS'
-        report_name       (String): Name of the cost usage report to download.
+        None
 
     Returns:
         files (List) List of filenames with full local path.
@@ -56,15 +58,20 @@ def get_report_files(customer_name,
     log_statement = stmt.format(access_credential, report_source, customer_name, provider_type)
     LOG.info(log_statement)
 
-    try:
-        downloader = ReportDownloader(customer_name=customer_name,
-                                      access_credential=access_credential,
-                                      report_source=report_source,
-                                      provider_type=provider_type,
-                                      report_name=report_name)
-    except ReportDownloaderError as err:
-        LOG.error(str(err))
-        return []
+    downloader = ReportDownloader(customer_name=customer_name,
+                                  access_credential=access_credential,
+                                  report_source=report_source,
+                                  provider_type=provider_type,
+                                  report_name=report_name)
 
     reports = downloader.get_current_report()
-    return reports
+
+    for report_dict in reports:
+        cur_request = {}
+        cur_request['schema_name'] = schema_name
+        cur_request['report_path'] = report_dict.get('file')
+        cur_request['compression'] = report_dict.get('compression')
+
+        process_report_file.delay(cur_request)
+
+    # return reports


### PR DESCRIPTION
## NOT TO BE MERGED

This is really here just as a proof of concept of the simplest way to get what we had async. It's short-cutty and dirty, so don't take this as a implied endorsement of doing things this way on my part. I chained the tasks to short cut out the results back end. The periodic task hasn't been tested at all. Et cetera.

How to run this:

1) Make sure Postgres and RabbitMQ are running in OpenShift

2) Setup a provider in koku pointed to a valid roleARN and cost usage report S3 bucket (I'm using the `cost-usage-bucket` and roleARN in our/Chris's AWS account). 

3) run `make oc-serve` from masu

4) Hit `http://127.0.0.1:5000/api/v1/download/` in a browser

5) Run `celery worker -A masu.celery.worker:CELERY --loglevel=info` in another terminal window