### PR TITLE
Ocp on aws initial cost calculation

### DIFF
--- a/masu/database/__init__.py
+++ b/masu/database/__init__.py
@@ -26,7 +26,8 @@ AWS_CUR_TABLE_MAP = {
     'product': 'reporting_awscostentryproduct',
     'pricing': 'reporting_awscostentrypricing',
     'reservation': 'reporting_awscostentryreservation',
-    'tags_summary': 'reporting_awstags_summary'
+    'tags_summary': 'reporting_awstags_summary',
+    'ocp_on_aws_daily_summary': 'reporting_ocpawscostlineitem_daily_summary'
 }
 
 OCP_REPORT_TABLE_MAP = {

--- a/masu/database/aws_report_db_accessor.py
+++ b/masu/database/aws_report_db_accessor.py
@@ -209,7 +209,7 @@ class AWSReportDBAccessor(ReportDBAccessorBase):
         self._cursor.execute(agg_sql)
         self._pg2_conn.commit()
         self._vacuum_table(table_name)
-        LOG.info(f'Finished updating %s.', table_name)
+        LOG.info('Finished updating %s.', table_name)
 
     def mark_bill_as_finalized(self, bill_id):
         """Mark a bill in the database as finalized."""
@@ -236,7 +236,7 @@ class AWSReportDBAccessor(ReportDBAccessorBase):
         self._cursor.execute(agg_sql)
         self._pg2_conn.commit()
         self._vacuum_table(table_name)
-        LOG.info(f'Finished updating %s.', table_name)
+        LOG.info('Finished updating %s.', table_name)
 
     def populate_ocp_on_aws_cost_daily_summary(self, start_date, end_date):
         """Populate the daily cost aggregated summary for OCP on AWS.

--- a/masu/database/aws_report_db_accessor.py
+++ b/masu/database/aws_report_db_accessor.py
@@ -237,3 +237,31 @@ class AWSReportDBAccessor(ReportDBAccessorBase):
         self._pg2_conn.commit()
         self._vacuum_table(table_name)
         LOG.info(f'Finished updating %s.', table_name)
+
+    def populate_ocp_on_aws_cost_daily_summary(self, start_date, end_date):
+        """Populate the daily cost aggregated summary for OCP on AWS.
+
+        Args:
+            start_date (datetime.date) The date to start populating the table.
+            end_date (datetime.date) The date to end on.
+
+        Returns
+            (None)
+
+        """
+        table_name = AWS_CUR_TABLE_MAP['ocp_on_aws_daily_summary']
+        summary_sql = pkgutil.get_data(
+            'masu.database',
+            'sql/reporting_ocpawscostlineitem_daily_summary.sql'
+        )
+        summary_sql = summary_sql.decode('utf-8').format(
+            uuid=str(uuid.uuid4()).replace('-', '_'),
+            start_date=start_date,
+            end_date=end_date
+        )
+        LOG.info('Updating %s from %s to %s.',
+                 table_name, start_date, end_date)
+        self._cursor.execute(summary_sql)
+        self._pg2_conn.commit()
+        self._vacuum_table(table_name)
+        LOG.info('Finished updating %s.', table_name)

--- a/masu/database/sql/reporting_ocpawscostlineitem_daily_summary.sql
+++ b/masu/database/sql/reporting_ocpawscostlineitem_daily_summary.sql
@@ -1,0 +1,83 @@
+-- Place our query in a temporary table
+CREATE TEMPORARY TABLE reporting_ocpawscostlineitem_daily_summary_{uuid} AS (
+    SELECT li.cluster_id,
+        li.cluster_alias,
+        li.namespace,
+        li.pod,
+        li.node,
+        li.resource_id,
+        li.usage_start,
+        li.usage_end,
+        li.pod_labels,
+        li.product_code,
+        p.product_family,
+        li.usage_account_id,
+        aa.id as account_alias_id,
+        li.availability_zone,
+        p.region,
+        pr.unit,
+        li.tags,
+        li.unblended_cost,
+        (li.pod_usage_cpu_core_seconds / li.node_capacity_cpu_core_seconds) *
+            li.unblended_cost as pod_cost
+    FROM reporting_ocpawscostlineitem_daily as li
+    JOIN reporting_awscostentryproduct AS p
+        ON li.cost_entry_product_id = p.id
+    LEFT JOIN reporting_awscostentrypricing as pr
+        ON li.cost_entry_pricing_id = pr.id
+    LEFT JOIN reporting_awsaccountalias AS aa
+        ON li.usage_account_id = aa.account_id
+    WHERE li.usage_start >= '{start_date}'
+        AND li.usage_start <= '{end_date}'
+)
+;
+
+-- Clear out old entries first
+DELETE FROM reporting_ocpawscostlineitem_daily_summary
+WHERE usage_start >= '{start_date}'
+    AND usage_start <= '{end_date}'
+;
+
+-- Populate the daily aggregate line item data
+INSERT INTO reporting_ocpawscostlineitem_daily_summary (
+    cluster_id,
+    cluster_alias,
+    namespace,
+    pod,
+    node,
+    resource_id,
+    usage_start,
+    usage_end,
+    pod_labels,
+    product_code,
+    product_family,
+    usage_account_id,
+    account_alias_id,
+    availability_zone,
+    region,
+    unit,
+    tags,
+    unblended_cost,
+    pod_cost
+)
+    SELECT cluster_id,
+        cluster_alias,
+        namespace,
+        pod,
+        node,
+        resource_id,
+        usage_start,
+        usage_end,
+        pod_labels,
+        product_code,
+        product_family,
+        usage_account_id,
+        account_alias_id,
+        availability_zone,
+        region,
+        unit,
+        tags,
+        unblended_cost,
+        pod_cost
+    FROM reporting_ocpawscostlineitem_daily_summary_{uuid}
+;

--- a/masu/processor/aws/aws_report_summary_updater.py
+++ b/masu/processor/aws/aws_report_summary_updater.py
@@ -108,6 +108,7 @@ class AWSReportSummaryUpdater:
             accessor.populate_line_item_daily_summary_table(start_date, end_date)
             accessor.populate_line_item_aggregate_table()
             accessor.populate_tags_summary_table()
+            accessor.populate_ocp_on_aws_cost_daily_summary(start_date, end_date)
 
             for bill in bills:
                 if bill.summary_data_creation_datetime is None:

--- a/tests/database/helpers.py
+++ b/tests/database/helpers.py
@@ -122,7 +122,8 @@ class ReportObjectCreator:
                                     cost_entry,
                                     product,
                                     pricing,
-                                    reservation):
+                                    reservation,
+                                    resource_id=None):
         """Create a cost entry line item database object for test."""
         table_name = AWS_CUR_TABLE_MAP['line_item']
         data = self.create_columns_for_table(table_name)
@@ -139,6 +140,8 @@ class ReportObjectCreator:
             'environment': random.choice(['dev', 'qa', 'prod']),
             self.fake.pystr()[:8]: self.fake.pystr()[:8]
         }
+        if resource_id:
+            row.resource_id = resource_id
         self.db_accessor._session.add(row)
         self.db_accessor._session.commit()
 
@@ -189,7 +192,8 @@ class ReportObjectCreator:
 
     def create_ocp_usage_line_item(self,
                                    report_period,
-                                   report):
+                                   report,
+                                   resource_id=None):
         """Create an OCP usage line item database object for test."""
         table_name = OCP_REPORT_TABLE_MAP['line_item']
         data = self.create_columns_for_table(table_name)
@@ -197,6 +201,9 @@ class ReportObjectCreator:
         for key in data:
             if 'byte' in key:
                 data[key] = data[key] * Decimal(pow(2, 30))
+
+        if resource_id:
+            data['resource_id'] = resource_id
 
         row = self.db_accessor.create_db_object(table_name, data)
 

--- a/tests/database/test_reporting_common_db_accessor.py
+++ b/tests/database/test_reporting_common_db_accessor.py
@@ -60,6 +60,7 @@ class ReportingCommonDBAccessorTest(MasuTestCase):
         tables.remove(AWS_CUR_TABLE_MAP['line_item_daily_summary'])
         tables.remove(AWS_CUR_TABLE_MAP['line_item_aggregates'])
         tables.remove(AWS_CUR_TABLE_MAP['tags_summary'])
+        tables.remove(AWS_CUR_TABLE_MAP['ocp_on_aws_daily_summary'])
         for table in tables:
             self.assertIn(table, keys)
 

--- a/tests/processor/aws/test_aws_report_processor.py
+++ b/tests/processor/aws/test_aws_report_processor.py
@@ -164,7 +164,8 @@ class AWSReportProcessorTest(MasuTestCase):
             table = getattr(report_schema, table_name)
             count = report_db._session.query(table).count()
 
-            if table_name == 'reporting_awscostentryreservation':
+            if table_name in ('reporting_awscostentryreservation',
+                              'reporting_ocpawscostlineitem_daily_summary'):
                 self.assertTrue(count >= counts[table_name])
             else:
                 self.assertTrue(count > counts[table_name])
@@ -191,7 +192,8 @@ class AWSReportProcessorTest(MasuTestCase):
             table = getattr(report_schema, table_name)
             count = report_db._session.query(table).count()
 
-            if table_name == 'reporting_awscostentryreservation':
+            if table_name in ('reporting_awscostentryreservation',
+                              'reporting_ocpawscostlineitem_daily_summary'):
                 self.assertTrue(count >= counts[table_name])
             else:
                 self.assertTrue(count > counts[table_name])

--- a/tests/processor/aws/test_aws_report_summary_updater.py
+++ b/tests/processor/aws/test_aws_report_summary_updater.py
@@ -116,11 +116,12 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
             self.manifest_accessor.delete(manifest)
         self.manifest_accessor.commit()
 
+    @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_cost_daily_summary')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_aggregate_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_summary_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_table')
     def test_update_summary_tables_with_manifest(self, mock_daily, mock_summary,
-                                                 mock_agg):
+                                                 mock_agg, mock_ocp):
         """Test that summary tables are properly run."""
         self.manifest.num_processed_files = self.manifest.num_total_files
         manifest_id = self.manifest.id
@@ -148,17 +149,19 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         mock_daily.assert_called_with(expected_start_date, expected_end_date)
         mock_summary.assert_called_with(expected_start_date, expected_end_date)
         mock_agg.assert_called()
+        mock_ocp.assert_called_with(expected_start_date, expected_end_date)
 
         with AWSReportDBAccessor('acct10001', self.column_map) as accessor:
             bill = accessor.get_cost_entry_bills_by_date(bill_date)[0]
             self.assertIsNotNone(bill.summary_data_creation_datetime)
             self.assertIsNotNone(bill.summary_data_updated_datetime)
 
+    @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_cost_daily_summary')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_aggregate_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_summary_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_table')
     def test_update_summary_tables_new_bill(self, mock_daily, mock_summary,
-                                            mock_agg):
+                                            mock_agg, mock_ocp):
         """Test that summary tables are run for a full month."""
 
         self.manifest.num_processed_files = self.manifest.num_total_files
@@ -192,17 +195,19 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         mock_daily.assert_called_with(expected_start_date, expected_end_date)
         mock_summary.assert_called_with(expected_start_date, expected_end_date)
         mock_agg.assert_called()
+        mock_ocp.assert_called_with(expected_start_date, expected_end_date)
 
         with AWSReportDBAccessor('acct10001', self.column_map) as accessor:
             bill = accessor.get_cost_entry_bills_by_date(bill_date)[0]
             self.assertIsNotNone(bill.summary_data_creation_datetime)
             self.assertIsNotNone(bill.summary_data_updated_datetime)
 
+    @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_cost_daily_summary')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_aggregate_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_summary_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_table')
     def test_update_summary_tables_new_bill_last_month(self, mock_daily,
-                                                       mock_summary, mock_agg):
+                                                       mock_summary, mock_agg, mock_ocp):
         """Test that summary tables are run for the month of the manifest."""
         billing_start = self.date_accessor.today_with_timezone('UTC').replace(day=1) + relativedelta(months=-1)
         manifest_dict = {
@@ -248,19 +253,22 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         mock_daily.assert_called_with(expected_start_date, expected_end_date)
         mock_summary.assert_called_with(expected_start_date, expected_end_date)
         mock_agg.assert_called()
+        mock_ocp.assert_called_with(expected_start_date, expected_end_date)
 
         with AWSReportDBAccessor('acct10001', self.column_map) as accessor:
             bill = accessor.get_cost_entry_bills_by_date(bill_date)[0]
             self.assertIsNotNone(bill.summary_data_creation_datetime)
             self.assertIsNotNone(bill.summary_data_updated_datetime)
 
+    @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_cost_daily_summary')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_aggregate_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_summary_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_table')
     def test_update_summary_tables_new_bill_not_done_processing(self,
                                                                 mock_daily,
                                                                 mock_summary,
-                                                                mock_agg):
+                                                                mock_agg,
+                                                                mock_ocp):
         """Test that summary tables are not run for a full month."""
 
         manifest_id = self.manifest.id
@@ -291,17 +299,19 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         mock_daily.assert_called_with(expected_start_date, expected_end_date)
         mock_summary.assert_called_with(expected_start_date, expected_end_date)
         mock_agg.assert_called()
+        mock_ocp.assert_called_with(expected_start_date, expected_end_date)
 
         with AWSReportDBAccessor('acct10001', self.column_map) as accessor:
             bill = accessor.get_cost_entry_bills_by_date(bill_date)[0]
             self.assertIsNotNone(bill.summary_data_creation_datetime)
             self.assertIsNotNone(bill.summary_data_updated_datetime)
 
+    @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_cost_daily_summary')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_aggregate_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_summary_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_table')
     def test_update_summary_tables_finalized_bill(self, mock_daily, mock_summary,
-                                                  mock_agg):
+                                                  mock_agg, mock_ocp):
         """Test that summary tables are run for a full month."""
         self.manifest.num_processed_files = self.manifest.num_total_files
         manifest_id = self.manifest.id
@@ -336,19 +346,22 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         mock_daily.assert_called_with(expected_start_date, expected_end_date)
         mock_summary.assert_called_with(expected_start_date, expected_end_date)
         mock_agg.assert_called()
+        mock_ocp.assert_called_with(expected_start_date, expected_end_date)
 
         with AWSReportDBAccessor('acct10001', self.column_map) as accessor:
             bill = accessor.get_cost_entry_bills_by_date(bill_date)[0]
             self.assertIsNotNone(bill.summary_data_creation_datetime)
             self.assertIsNotNone(bill.summary_data_updated_datetime)
 
+    @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_cost_daily_summary')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_aggregate_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_summary_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_table')
     def test_update_summary_tables_finalized_bill_not_done_proc(self,
                                                                 mock_daily,
                                                                 mock_summary,
-                                                                mock_agg):
+                                                                mock_agg,
+                                                                mock_ocp):
         """Test that summary tables are run for a full month."""
         manifest_id = self.manifest.id
 
@@ -380,17 +393,19 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         mock_daily.assert_called_with(expected_start_date, expected_end_date)
         mock_summary.assert_called_with(expected_start_date, expected_end_date)
         mock_agg.assert_called()
+        mock_ocp.assert_called_with(expected_start_date, expected_end_date)
 
         with AWSReportDBAccessor('acct10001', self.column_map) as accessor:
             bill = accessor.get_cost_entry_bills_by_date(bill_date)[0]
             self.assertIsNotNone(bill.summary_data_creation_datetime)
             self.assertIsNotNone(bill.summary_data_updated_datetime)
 
+    @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_ocp_on_aws_cost_daily_summary')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_aggregate_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_summary_table')
     @patch('masu.processor.aws.aws_report_summary_updater.AWSReportDBAccessor.populate_line_item_daily_table')
     def test_update_summary_tables_without_manifest(self, mock_daily, mock_summary,
-                                                    mock_agg):
+                                                    mock_agg, mock_ocp):
         """Test that summary tables are properly run without a manifest."""
 
         start_date = DateAccessor().today_with_timezone('UTC')
@@ -412,6 +427,7 @@ class AWSReportSummaryUpdaterTest(MasuTestCase):
         mock_daily.assert_called_with(expected_start_date, expected_end_date)
         mock_summary.assert_called_with(expected_start_date, expected_end_date)
         mock_agg.assert_called()
+        mock_ocp.assert_called_with(expected_start_date, expected_end_date)
 
         with AWSReportDBAccessor('acct10001', self.column_map) as accessor:
             bill = accessor.get_cost_entry_bills_by_date(bill_date)[0]

--- a/tests/sql/test.sql
+++ b/tests/sql/test.sql
@@ -16,20 +16,13 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: DATABASE postgres; Type: COMMENT; Schema: -; Owner: postgres
---
-
-COMMENT ON DATABASE postgres IS 'default administrative connection database';
-
-
---
--- Name: acct10001; Type: SCHEMA; Schema: -; Owner: postgres
+-- Name: acct10001; Type: SCHEMA; Schema: -; Owner: kokuadmin
 --
 
 CREATE SCHEMA acct10001;
 
 
-ALTER SCHEMA acct10001 OWNER TO postgres;
+ALTER SCHEMA acct10001 OWNER TO kokuadmin;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
@@ -50,7 +43,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: django_migrations; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: django_migrations; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.django_migrations (
@@ -61,10 +54,10 @@ CREATE TABLE acct10001.django_migrations (
 );
 
 
-ALTER TABLE acct10001.django_migrations OWNER TO postgres;
+ALTER TABLE acct10001.django_migrations OWNER TO kokuadmin;
 
 --
--- Name: django_migrations_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: django_migrations_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.django_migrations_id_seq
@@ -75,17 +68,17 @@ CREATE SEQUENCE acct10001.django_migrations_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.django_migrations_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.django_migrations_id_seq OWNER TO kokuadmin;
 
 --
--- Name: django_migrations_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: django_migrations_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.django_migrations_id_seq OWNED BY acct10001.django_migrations.id;
 
 
 --
--- Name: rates_rate; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: rates_rate; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.rates_rate (
@@ -97,10 +90,10 @@ CREATE TABLE acct10001.rates_rate (
 );
 
 
-ALTER TABLE acct10001.rates_rate OWNER TO postgres;
+ALTER TABLE acct10001.rates_rate OWNER TO kokuadmin;
 
 --
--- Name: rates_rate_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: rates_rate_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.rates_rate_id_seq
@@ -111,17 +104,17 @@ CREATE SEQUENCE acct10001.rates_rate_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.rates_rate_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.rates_rate_id_seq OWNER TO kokuadmin;
 
 --
--- Name: rates_rate_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: rates_rate_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.rates_rate_id_seq OWNED BY acct10001.rates_rate.id;
 
 
 --
--- Name: reporting_awsaccountalias; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awsaccountalias; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awsaccountalias (
@@ -131,10 +124,10 @@ CREATE TABLE acct10001.reporting_awsaccountalias (
 );
 
 
-ALTER TABLE acct10001.reporting_awsaccountalias OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awsaccountalias OWNER TO kokuadmin;
 
 --
--- Name: reporting_awsaccountalias_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awsaccountalias_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awsaccountalias_id_seq
@@ -145,17 +138,17 @@ CREATE SEQUENCE acct10001.reporting_awsaccountalias_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awsaccountalias_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awsaccountalias_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awsaccountalias_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awsaccountalias_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awsaccountalias_id_seq OWNED BY acct10001.reporting_awsaccountalias.id;
 
 
 --
--- Name: reporting_awscostentry; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentry; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentry (
@@ -166,10 +159,10 @@ CREATE TABLE acct10001.reporting_awscostentry (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentry OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentry OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentry_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentry_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentry_id_seq
@@ -180,17 +173,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentry_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentry_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentry_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentry_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentry_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentry_id_seq OWNED BY acct10001.reporting_awscostentry.id;
 
 
 --
--- Name: reporting_awscostentrybill; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrybill; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentrybill (
@@ -207,10 +200,10 @@ CREATE TABLE acct10001.reporting_awscostentrybill (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentrybill OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrybill OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrybill_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrybill_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentrybill_id_seq
@@ -221,17 +214,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentrybill_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentrybill_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrybill_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrybill_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrybill_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentrybill_id_seq OWNED BY acct10001.reporting_awscostentrybill.id;
 
 
 --
--- Name: reporting_awscostentrylineitem; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentrylineitem (
@@ -272,10 +265,10 @@ CREATE TABLE acct10001.reporting_awscostentrylineitem (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentrylineitem OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrylineitem OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrylineitem_aggregates; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_aggregates; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentrylineitem_aggregates (
@@ -294,10 +287,10 @@ CREATE TABLE acct10001.reporting_awscostentrylineitem_aggregates (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentrylineitem_aggregates OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrylineitem_aggregates OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrylineitem_aggregates_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_aggregates_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentrylineitem_aggregates_id_seq
@@ -308,17 +301,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentrylineitem_aggregates_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentrylineitem_aggregates_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrylineitem_aggregates_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrylineitem_aggregates_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_aggregates_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentrylineitem_aggregates_id_seq OWNED BY acct10001.reporting_awscostentrylineitem_aggregates.id;
 
 
 --
--- Name: reporting_awscostentrylineitem_daily; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentrylineitem_daily (
@@ -350,10 +343,10 @@ CREATE TABLE acct10001.reporting_awscostentrylineitem_daily (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentrylineitem_daily OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrylineitem_daily OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrylineitem_daily_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentrylineitem_daily_id_seq
@@ -364,17 +357,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentrylineitem_daily_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentrylineitem_daily_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrylineitem_daily_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrylineitem_daily_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentrylineitem_daily_id_seq OWNED BY acct10001.reporting_awscostentrylineitem_daily.id;
 
 
 --
--- Name: reporting_awscostentrylineitem_daily_summary; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_summary; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentrylineitem_daily_summary (
@@ -405,10 +398,10 @@ CREATE TABLE acct10001.reporting_awscostentrylineitem_daily_summary (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentrylineitem_daily_summary OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrylineitem_daily_summary OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrylineitem_daily_summary_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_summary_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentrylineitem_daily_summary_id_seq
@@ -419,17 +412,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentrylineitem_daily_summary_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentrylineitem_daily_summary_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrylineitem_daily_summary_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrylineitem_daily_summary_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_summary_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentrylineitem_daily_summary_id_seq OWNED BY acct10001.reporting_awscostentrylineitem_daily_summary.id;
 
 
 --
--- Name: reporting_awscostentrylineitem_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentrylineitem_id_seq
@@ -440,17 +433,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentrylineitem_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentrylineitem_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrylineitem_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrylineitem_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentrylineitem_id_seq OWNED BY acct10001.reporting_awscostentrylineitem.id;
 
 
 --
--- Name: reporting_awscostentrypricing; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrypricing; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentrypricing (
@@ -460,10 +453,10 @@ CREATE TABLE acct10001.reporting_awscostentrypricing (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentrypricing OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrypricing OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrypricing_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrypricing_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentrypricing_id_seq
@@ -474,17 +467,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentrypricing_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentrypricing_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentrypricing_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentrypricing_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrypricing_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentrypricing_id_seq OWNED BY acct10001.reporting_awscostentrypricing.id;
 
 
 --
--- Name: reporting_awscostentryproduct; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryproduct; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentryproduct (
@@ -502,10 +495,10 @@ CREATE TABLE acct10001.reporting_awscostentryproduct (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentryproduct OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentryproduct OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentryproduct_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryproduct_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentryproduct_id_seq
@@ -516,17 +509,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentryproduct_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentryproduct_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentryproduct_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentryproduct_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryproduct_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentryproduct_id_seq OWNED BY acct10001.reporting_awscostentryproduct.id;
 
 
 --
--- Name: reporting_awscostentryreservation; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryreservation; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awscostentryreservation (
@@ -540,10 +533,10 @@ CREATE TABLE acct10001.reporting_awscostentryreservation (
 );
 
 
-ALTER TABLE acct10001.reporting_awscostentryreservation OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentryreservation OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentryreservation_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryreservation_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_awscostentryreservation_id_seq
@@ -554,17 +547,17 @@ CREATE SEQUENCE acct10001.reporting_awscostentryreservation_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_awscostentryreservation_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awscostentryreservation_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_awscostentryreservation_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryreservation_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_awscostentryreservation_id_seq OWNED BY acct10001.reporting_awscostentryreservation.id;
 
 
 --
--- Name: reporting_awstags_summary; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_awstags_summary; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_awstags_summary (
@@ -573,86 +566,10 @@ CREATE TABLE acct10001.reporting_awstags_summary (
 );
 
 
-ALTER TABLE acct10001.reporting_awstags_summary OWNER TO postgres;
+ALTER TABLE acct10001.reporting_awstags_summary OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagelineitem; Type: TABLE; Schema: acct10001; Owner: postgres
---
-
-CREATE TABLE acct10001.reporting_ocpusagelineitem (
-    id bigint NOT NULL,
-    namespace character varying(253) NOT NULL,
-    pod character varying(253) NOT NULL,
-    node character varying(253) NOT NULL,
-    pod_usage_cpu_core_seconds numeric(24,6),
-    pod_limit_cpu_core_seconds numeric(24,6),
-    report_id integer NOT NULL,
-    report_period_id integer NOT NULL,
-    pod_limit_memory_byte_seconds numeric(24,6),
-    pod_request_cpu_core_seconds numeric(24,6),
-    pod_request_memory_byte_seconds numeric(24,6),
-    pod_usage_memory_byte_seconds numeric(24,6),
-    node_capacity_cpu_core_seconds numeric(24,6),
-    node_capacity_cpu_cores numeric(24,6),
-    node_capacity_memory_byte_seconds numeric(24,6),
-    node_capacity_memory_bytes numeric(24,6),
-    pod_labels jsonb,
-    resource_id character varying(253)
-);
-
-
-ALTER TABLE acct10001.reporting_ocpusagelineitem OWNER TO postgres;
-
---
--- Name: reporting_ocpusagelineitem_aggregates; Type: TABLE; Schema: acct10001; Owner: postgres
---
-
-CREATE TABLE acct10001.reporting_ocpusagelineitem_aggregates (
-    id integer NOT NULL,
-    time_scope_value integer NOT NULL,
-    cluster_id character varying(50),
-    namespace character varying(253) NOT NULL,
-    pod character varying(253) NOT NULL,
-    node character varying(253) NOT NULL,
-    pod_usage_cpu_core_hours numeric(24,6),
-    pod_request_cpu_core_hours numeric(24,6),
-    pod_limit_cpu_core_hours numeric(24,6),
-    pod_usage_memory_gigabytes numeric(24,6),
-    pod_request_memory_gigabytes numeric(24,6),
-    pod_limit_memory_gigabytes numeric(24,6),
-    node_capacity_cpu_core_hours numeric(20,6),
-    node_capacity_cpu_cores numeric(20,6),
-    node_capacity_memory_byte_hours numeric(20,6),
-    node_capacity_memory_bytes numeric(20,6),
-    resource_id character varying(253)
-);
-
-
-ALTER TABLE acct10001.reporting_ocpusagelineitem_aggregates OWNER TO postgres;
-
---
--- Name: reporting_ocpusagelineitem_aggregates_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
---
-
-CREATE SEQUENCE acct10001.reporting_ocpusagelineitem_aggregates_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE acct10001.reporting_ocpusagelineitem_aggregates_id_seq OWNER TO postgres;
-
---
--- Name: reporting_ocpusagelineitem_aggregates_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
---
-
-ALTER SEQUENCE acct10001.reporting_ocpusagelineitem_aggregates_id_seq OWNED BY acct10001.reporting_ocpusagelineitem_aggregates.id;
-
-
---
--- Name: reporting_ocpusagelineitem_daily; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_ocpusagelineitem_daily (
@@ -682,10 +599,189 @@ CREATE TABLE acct10001.reporting_ocpusagelineitem_daily (
 );
 
 
-ALTER TABLE acct10001.reporting_ocpusagelineitem_daily OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagelineitem_daily OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagelineitem_daily_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpawscostlineitem_daily; Type: VIEW; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE VIEW acct10001.reporting_ocpawscostlineitem_daily AS
+ SELECT ocp.cluster_id,
+    ocp.cluster_alias,
+    ocp.namespace,
+    ocp.pod,
+    ocp.node,
+    ocp.pod_labels,
+    ocp.pod_usage_cpu_core_seconds,
+    ocp.pod_request_cpu_core_seconds,
+    ocp.pod_limit_cpu_core_seconds,
+    ocp.pod_usage_memory_byte_seconds,
+    ocp.pod_request_memory_byte_seconds,
+    ocp.node_capacity_cpu_cores,
+    ocp.node_capacity_cpu_core_seconds,
+    ocp.node_capacity_memory_bytes,
+    ocp.node_capacity_memory_byte_seconds,
+    ocp.cluster_capacity_cpu_core_seconds,
+    ocp.cluster_capacity_memory_byte_seconds,
+    aws.cost_entry_product_id,
+    aws.cost_entry_pricing_id,
+    aws.cost_entry_reservation_id,
+    aws.line_item_type,
+    aws.usage_account_id,
+    aws.usage_start,
+    aws.usage_end,
+    aws.product_code,
+    aws.usage_type,
+    aws.operation,
+    aws.availability_zone,
+    aws.resource_id,
+    aws.usage_amount,
+    aws.normalization_factor,
+    aws.normalized_usage_amount,
+    aws.currency_code,
+    aws.unblended_rate,
+    aws.unblended_cost,
+    aws.blended_rate,
+    aws.blended_cost,
+    aws.public_on_demand_cost,
+    aws.public_on_demand_rate,
+    aws.tax_type,
+    aws.tags
+   FROM (acct10001.reporting_awscostentrylineitem_daily aws
+     JOIN acct10001.reporting_ocpusagelineitem_daily ocp ON ((((aws.resource_id)::text = (ocp.resource_id)::text) AND ((aws.usage_start)::date = (ocp.usage_start)::date))));
+
+
+ALTER TABLE acct10001.reporting_ocpawscostlineitem_daily OWNER TO kokuadmin;
+
+--
+-- Name: reporting_ocpawscostlineitem_daily_summary; Type: TABLE; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE TABLE acct10001.reporting_ocpawscostlineitem_daily_summary (
+    id integer NOT NULL,
+    cluster_id character varying(50),
+    cluster_alias character varying(256),
+    namespace character varying(253) NOT NULL,
+    pod character varying(253) NOT NULL,
+    node character varying(253) NOT NULL,
+    resource_id character varying(253),
+    usage_start timestamp with time zone NOT NULL,
+    usage_end timestamp with time zone NOT NULL,
+    pod_labels jsonb,
+    product_code character varying(50) NOT NULL,
+    product_family character varying(150),
+    usage_account_id character varying(50) NOT NULL,
+    availability_zone character varying(50),
+    region character varying(50),
+    unit character varying(63),
+    tags jsonb,
+    unblended_cost numeric(17,9),
+    pod_cost numeric(24,6),
+    account_alias_id integer
+);
+
+
+ALTER TABLE acct10001.reporting_ocpawscostlineitem_daily_summary OWNER TO kokuadmin;
+
+--
+-- Name: reporting_ocpawscostlineitem_daily_summary_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE SEQUENCE acct10001.reporting_ocpawscostlineitem_daily_summary_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE acct10001.reporting_ocpawscostlineitem_daily_summary_id_seq OWNER TO kokuadmin;
+
+--
+-- Name: reporting_ocpawscostlineitem_daily_summary_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
+--
+
+ALTER SEQUENCE acct10001.reporting_ocpawscostlineitem_daily_summary_id_seq OWNED BY acct10001.reporting_ocpawscostlineitem_daily_summary.id;
+
+
+--
+-- Name: reporting_ocpusagelineitem; Type: TABLE; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE TABLE acct10001.reporting_ocpusagelineitem (
+    id bigint NOT NULL,
+    namespace character varying(253) NOT NULL,
+    pod character varying(253) NOT NULL,
+    node character varying(253) NOT NULL,
+    pod_usage_cpu_core_seconds numeric(24,6),
+    pod_limit_cpu_core_seconds numeric(24,6),
+    report_id integer NOT NULL,
+    report_period_id integer NOT NULL,
+    pod_limit_memory_byte_seconds numeric(24,6),
+    pod_request_cpu_core_seconds numeric(24,6),
+    pod_request_memory_byte_seconds numeric(24,6),
+    pod_usage_memory_byte_seconds numeric(24,6),
+    node_capacity_cpu_core_seconds numeric(24,6),
+    node_capacity_cpu_cores numeric(24,6),
+    node_capacity_memory_byte_seconds numeric(24,6),
+    node_capacity_memory_bytes numeric(24,6),
+    pod_labels jsonb,
+    resource_id character varying(253)
+);
+
+
+ALTER TABLE acct10001.reporting_ocpusagelineitem OWNER TO kokuadmin;
+
+--
+-- Name: reporting_ocpusagelineitem_aggregates; Type: TABLE; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE TABLE acct10001.reporting_ocpusagelineitem_aggregates (
+    id integer NOT NULL,
+    time_scope_value integer NOT NULL,
+    cluster_id character varying(50),
+    namespace character varying(253) NOT NULL,
+    pod character varying(253) NOT NULL,
+    node character varying(253) NOT NULL,
+    pod_usage_cpu_core_hours numeric(24,6),
+    pod_request_cpu_core_hours numeric(24,6),
+    pod_limit_cpu_core_hours numeric(24,6),
+    pod_usage_memory_gigabytes numeric(24,6),
+    pod_request_memory_gigabytes numeric(24,6),
+    pod_limit_memory_gigabytes numeric(24,6),
+    node_capacity_cpu_core_hours numeric(20,6),
+    node_capacity_cpu_cores numeric(20,6),
+    node_capacity_memory_byte_hours numeric(20,6),
+    node_capacity_memory_bytes numeric(20,6),
+    resource_id character varying(253)
+);
+
+
+ALTER TABLE acct10001.reporting_ocpusagelineitem_aggregates OWNER TO kokuadmin;
+
+--
+-- Name: reporting_ocpusagelineitem_aggregates_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE SEQUENCE acct10001.reporting_ocpusagelineitem_aggregates_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE acct10001.reporting_ocpusagelineitem_aggregates_id_seq OWNER TO kokuadmin;
+
+--
+-- Name: reporting_ocpusagelineitem_aggregates_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
+--
+
+ALTER SEQUENCE acct10001.reporting_ocpusagelineitem_aggregates_id_seq OWNED BY acct10001.reporting_ocpusagelineitem_aggregates.id;
+
+
+--
+-- Name: reporting_ocpusagelineitem_daily_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_ocpusagelineitem_daily_id_seq
@@ -696,17 +792,17 @@ CREATE SEQUENCE acct10001.reporting_ocpusagelineitem_daily_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_ocpusagelineitem_daily_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagelineitem_daily_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagelineitem_daily_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_ocpusagelineitem_daily_id_seq OWNED BY acct10001.reporting_ocpusagelineitem_daily.id;
 
 
 --
--- Name: reporting_ocpusagelineitem_daily_summary; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily_summary; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_ocpusagelineitem_daily_summary (
@@ -737,10 +833,10 @@ CREATE TABLE acct10001.reporting_ocpusagelineitem_daily_summary (
 );
 
 
-ALTER TABLE acct10001.reporting_ocpusagelineitem_daily_summary OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagelineitem_daily_summary OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagelineitem_daily_summary_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily_summary_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_ocpusagelineitem_daily_summary_id_seq
@@ -751,17 +847,17 @@ CREATE SEQUENCE acct10001.reporting_ocpusagelineitem_daily_summary_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_ocpusagelineitem_daily_summary_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagelineitem_daily_summary_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagelineitem_daily_summary_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily_summary_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_ocpusagelineitem_daily_summary_id_seq OWNED BY acct10001.reporting_ocpusagelineitem_daily_summary.id;
 
 
 --
--- Name: reporting_ocpusagelineitem_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_ocpusagelineitem_id_seq
@@ -772,17 +868,17 @@ CREATE SEQUENCE acct10001.reporting_ocpusagelineitem_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_ocpusagelineitem_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagelineitem_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagelineitem_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_ocpusagelineitem_id_seq OWNED BY acct10001.reporting_ocpusagelineitem.id;
 
 
 --
--- Name: reporting_ocpusagepodlabel_summary; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagepodlabel_summary; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_ocpusagepodlabel_summary (
@@ -791,10 +887,10 @@ CREATE TABLE acct10001.reporting_ocpusagepodlabel_summary (
 );
 
 
-ALTER TABLE acct10001.reporting_ocpusagepodlabel_summary OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagepodlabel_summary OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagereport; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_ocpusagereport (
@@ -805,10 +901,10 @@ CREATE TABLE acct10001.reporting_ocpusagereport (
 );
 
 
-ALTER TABLE acct10001.reporting_ocpusagereport OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagereport OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagereport_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_ocpusagereport_id_seq
@@ -819,17 +915,17 @@ CREATE SEQUENCE acct10001.reporting_ocpusagereport_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_ocpusagereport_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagereport_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagereport_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_ocpusagereport_id_seq OWNED BY acct10001.reporting_ocpusagereport.id;
 
 
 --
--- Name: reporting_ocpusagereportperiod; Type: TABLE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereportperiod; Type: TABLE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE TABLE acct10001.reporting_ocpusagereportperiod (
@@ -843,10 +939,10 @@ CREATE TABLE acct10001.reporting_ocpusagereportperiod (
 );
 
 
-ALTER TABLE acct10001.reporting_ocpusagereportperiod OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagereportperiod OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagereportperiod_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereportperiod_id_seq; Type: SEQUENCE; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE SEQUENCE acct10001.reporting_ocpusagereportperiod_id_seq
@@ -857,17 +953,17 @@ CREATE SEQUENCE acct10001.reporting_ocpusagereportperiod_id_seq
     CACHE 1;
 
 
-ALTER TABLE acct10001.reporting_ocpusagereportperiod_id_seq OWNER TO postgres;
+ALTER TABLE acct10001.reporting_ocpusagereportperiod_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_ocpusagereportperiod_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereportperiod_id_seq; Type: SEQUENCE OWNED BY; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER SEQUENCE acct10001.reporting_ocpusagereportperiod_id_seq OWNED BY acct10001.reporting_ocpusagereportperiod.id;
 
 
 --
--- Name: api_customer; Type: TABLE; Schema: public; Owner: postgres
+-- Name: api_customer; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.api_customer (
@@ -879,10 +975,10 @@ CREATE TABLE public.api_customer (
 );
 
 
-ALTER TABLE public.api_customer OWNER TO postgres;
+ALTER TABLE public.api_customer OWNER TO kokuadmin;
 
 --
--- Name: api_customer_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: api_customer_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.api_customer_id_seq
@@ -893,17 +989,17 @@ CREATE SEQUENCE public.api_customer_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.api_customer_id_seq OWNER TO postgres;
+ALTER TABLE public.api_customer_id_seq OWNER TO kokuadmin;
 
 --
--- Name: api_customer_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: api_customer_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.api_customer_id_seq OWNED BY public.api_customer.id;
 
 
 --
--- Name: api_provider; Type: TABLE; Schema: public; Owner: postgres
+-- Name: api_provider; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.api_provider (
@@ -919,10 +1015,10 @@ CREATE TABLE public.api_provider (
 );
 
 
-ALTER TABLE public.api_provider OWNER TO postgres;
+ALTER TABLE public.api_provider OWNER TO kokuadmin;
 
 --
--- Name: api_provider_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: api_provider_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.api_provider_id_seq
@@ -933,17 +1029,17 @@ CREATE SEQUENCE public.api_provider_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.api_provider_id_seq OWNER TO postgres;
+ALTER TABLE public.api_provider_id_seq OWNER TO kokuadmin;
 
 --
--- Name: api_provider_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: api_provider_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.api_provider_id_seq OWNED BY public.api_provider.id;
 
 
 --
--- Name: api_providerauthentication; Type: TABLE; Schema: public; Owner: postgres
+-- Name: api_providerauthentication; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.api_providerauthentication (
@@ -953,10 +1049,10 @@ CREATE TABLE public.api_providerauthentication (
 );
 
 
-ALTER TABLE public.api_providerauthentication OWNER TO postgres;
+ALTER TABLE public.api_providerauthentication OWNER TO kokuadmin;
 
 --
--- Name: api_providerauthentication_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: api_providerauthentication_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.api_providerauthentication_id_seq
@@ -967,17 +1063,17 @@ CREATE SEQUENCE public.api_providerauthentication_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.api_providerauthentication_id_seq OWNER TO postgres;
+ALTER TABLE public.api_providerauthentication_id_seq OWNER TO kokuadmin;
 
 --
--- Name: api_providerauthentication_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: api_providerauthentication_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.api_providerauthentication_id_seq OWNED BY public.api_providerauthentication.id;
 
 
 --
--- Name: api_providerbillingsource; Type: TABLE; Schema: public; Owner: postgres
+-- Name: api_providerbillingsource; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.api_providerbillingsource (
@@ -987,10 +1083,10 @@ CREATE TABLE public.api_providerbillingsource (
 );
 
 
-ALTER TABLE public.api_providerbillingsource OWNER TO postgres;
+ALTER TABLE public.api_providerbillingsource OWNER TO kokuadmin;
 
 --
--- Name: api_providerbillingsource_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: api_providerbillingsource_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.api_providerbillingsource_id_seq
@@ -1001,17 +1097,17 @@ CREATE SEQUENCE public.api_providerbillingsource_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.api_providerbillingsource_id_seq OWNER TO postgres;
+ALTER TABLE public.api_providerbillingsource_id_seq OWNER TO kokuadmin;
 
 --
--- Name: api_providerbillingsource_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: api_providerbillingsource_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.api_providerbillingsource_id_seq OWNED BY public.api_providerbillingsource.id;
 
 
 --
--- Name: api_tenant; Type: TABLE; Schema: public; Owner: postgres
+-- Name: api_tenant; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.api_tenant (
@@ -1020,10 +1116,10 @@ CREATE TABLE public.api_tenant (
 );
 
 
-ALTER TABLE public.api_tenant OWNER TO postgres;
+ALTER TABLE public.api_tenant OWNER TO kokuadmin;
 
 --
--- Name: api_tenant_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: api_tenant_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.api_tenant_id_seq
@@ -1034,17 +1130,17 @@ CREATE SEQUENCE public.api_tenant_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.api_tenant_id_seq OWNER TO postgres;
+ALTER TABLE public.api_tenant_id_seq OWNER TO kokuadmin;
 
 --
--- Name: api_tenant_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: api_tenant_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.api_tenant_id_seq OWNED BY public.api_tenant.id;
 
 
 --
--- Name: api_user; Type: TABLE; Schema: public; Owner: postgres
+-- Name: api_user; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.api_user (
@@ -1058,10 +1154,10 @@ CREATE TABLE public.api_user (
 );
 
 
-ALTER TABLE public.api_user OWNER TO postgres;
+ALTER TABLE public.api_user OWNER TO kokuadmin;
 
 --
--- Name: api_user_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: api_user_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.api_user_id_seq
@@ -1072,17 +1168,17 @@ CREATE SEQUENCE public.api_user_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.api_user_id_seq OWNER TO postgres;
+ALTER TABLE public.api_user_id_seq OWNER TO kokuadmin;
 
 --
--- Name: api_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: api_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.api_user_id_seq OWNED BY public.api_user.id;
 
 
 --
--- Name: api_userpreference; Type: TABLE; Schema: public; Owner: postgres
+-- Name: api_userpreference; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.api_userpreference (
@@ -1095,10 +1191,10 @@ CREATE TABLE public.api_userpreference (
 );
 
 
-ALTER TABLE public.api_userpreference OWNER TO postgres;
+ALTER TABLE public.api_userpreference OWNER TO kokuadmin;
 
 --
--- Name: api_userpreference_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: api_userpreference_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.api_userpreference_id_seq
@@ -1109,17 +1205,17 @@ CREATE SEQUENCE public.api_userpreference_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.api_userpreference_id_seq OWNER TO postgres;
+ALTER TABLE public.api_userpreference_id_seq OWNER TO kokuadmin;
 
 --
--- Name: api_userpreference_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: api_userpreference_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.api_userpreference_id_seq OWNED BY public.api_userpreference.id;
 
 
 --
--- Name: auth_group; Type: TABLE; Schema: public; Owner: postgres
+-- Name: auth_group; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.auth_group (
@@ -1128,10 +1224,10 @@ CREATE TABLE public.auth_group (
 );
 
 
-ALTER TABLE public.auth_group OWNER TO postgres;
+ALTER TABLE public.auth_group OWNER TO kokuadmin;
 
 --
--- Name: auth_group_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: auth_group_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.auth_group_id_seq
@@ -1142,17 +1238,17 @@ CREATE SEQUENCE public.auth_group_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.auth_group_id_seq OWNER TO postgres;
+ALTER TABLE public.auth_group_id_seq OWNER TO kokuadmin;
 
 --
--- Name: auth_group_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: auth_group_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.auth_group_id_seq OWNED BY public.auth_group.id;
 
 
 --
--- Name: auth_group_permissions; Type: TABLE; Schema: public; Owner: postgres
+-- Name: auth_group_permissions; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.auth_group_permissions (
@@ -1162,10 +1258,10 @@ CREATE TABLE public.auth_group_permissions (
 );
 
 
-ALTER TABLE public.auth_group_permissions OWNER TO postgres;
+ALTER TABLE public.auth_group_permissions OWNER TO kokuadmin;
 
 --
--- Name: auth_group_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: auth_group_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.auth_group_permissions_id_seq
@@ -1176,17 +1272,17 @@ CREATE SEQUENCE public.auth_group_permissions_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.auth_group_permissions_id_seq OWNER TO postgres;
+ALTER TABLE public.auth_group_permissions_id_seq OWNER TO kokuadmin;
 
 --
--- Name: auth_group_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: auth_group_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.auth_group_permissions_id_seq OWNED BY public.auth_group_permissions.id;
 
 
 --
--- Name: auth_permission; Type: TABLE; Schema: public; Owner: postgres
+-- Name: auth_permission; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.auth_permission (
@@ -1197,10 +1293,10 @@ CREATE TABLE public.auth_permission (
 );
 
 
-ALTER TABLE public.auth_permission OWNER TO postgres;
+ALTER TABLE public.auth_permission OWNER TO kokuadmin;
 
 --
--- Name: auth_permission_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: auth_permission_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.auth_permission_id_seq
@@ -1211,17 +1307,17 @@ CREATE SEQUENCE public.auth_permission_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.auth_permission_id_seq OWNER TO postgres;
+ALTER TABLE public.auth_permission_id_seq OWNER TO kokuadmin;
 
 --
--- Name: auth_permission_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: auth_permission_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.auth_permission_id_seq OWNED BY public.auth_permission.id;
 
 
 --
--- Name: auth_user; Type: TABLE; Schema: public; Owner: postgres
+-- Name: auth_user; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.auth_user (
@@ -1239,10 +1335,10 @@ CREATE TABLE public.auth_user (
 );
 
 
-ALTER TABLE public.auth_user OWNER TO postgres;
+ALTER TABLE public.auth_user OWNER TO kokuadmin;
 
 --
--- Name: auth_user_groups; Type: TABLE; Schema: public; Owner: postgres
+-- Name: auth_user_groups; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.auth_user_groups (
@@ -1252,10 +1348,10 @@ CREATE TABLE public.auth_user_groups (
 );
 
 
-ALTER TABLE public.auth_user_groups OWNER TO postgres;
+ALTER TABLE public.auth_user_groups OWNER TO kokuadmin;
 
 --
--- Name: auth_user_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: auth_user_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.auth_user_groups_id_seq
@@ -1266,17 +1362,17 @@ CREATE SEQUENCE public.auth_user_groups_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.auth_user_groups_id_seq OWNER TO postgres;
+ALTER TABLE public.auth_user_groups_id_seq OWNER TO kokuadmin;
 
 --
--- Name: auth_user_groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: auth_user_groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.auth_user_groups_id_seq OWNED BY public.auth_user_groups.id;
 
 
 --
--- Name: auth_user_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: auth_user_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.auth_user_id_seq
@@ -1287,17 +1383,17 @@ CREATE SEQUENCE public.auth_user_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.auth_user_id_seq OWNER TO postgres;
+ALTER TABLE public.auth_user_id_seq OWNER TO kokuadmin;
 
 --
--- Name: auth_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: auth_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.auth_user_id_seq OWNED BY public.auth_user.id;
 
 
 --
--- Name: auth_user_user_permissions; Type: TABLE; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.auth_user_user_permissions (
@@ -1307,10 +1403,10 @@ CREATE TABLE public.auth_user_user_permissions (
 );
 
 
-ALTER TABLE public.auth_user_user_permissions OWNER TO postgres;
+ALTER TABLE public.auth_user_user_permissions OWNER TO kokuadmin;
 
 --
--- Name: auth_user_user_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.auth_user_user_permissions_id_seq
@@ -1321,17 +1417,17 @@ CREATE SEQUENCE public.auth_user_user_permissions_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.auth_user_user_permissions_id_seq OWNER TO postgres;
+ALTER TABLE public.auth_user_user_permissions_id_seq OWNER TO kokuadmin;
 
 --
--- Name: auth_user_user_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.auth_user_user_permissions_id_seq OWNED BY public.auth_user_user_permissions.id;
 
 
 --
--- Name: django_admin_log; Type: TABLE; Schema: public; Owner: postgres
+-- Name: django_admin_log; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.django_admin_log (
@@ -1347,10 +1443,10 @@ CREATE TABLE public.django_admin_log (
 );
 
 
-ALTER TABLE public.django_admin_log OWNER TO postgres;
+ALTER TABLE public.django_admin_log OWNER TO kokuadmin;
 
 --
--- Name: django_admin_log_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: django_admin_log_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.django_admin_log_id_seq
@@ -1361,17 +1457,17 @@ CREATE SEQUENCE public.django_admin_log_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.django_admin_log_id_seq OWNER TO postgres;
+ALTER TABLE public.django_admin_log_id_seq OWNER TO kokuadmin;
 
 --
--- Name: django_admin_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: django_admin_log_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.django_admin_log_id_seq OWNED BY public.django_admin_log.id;
 
 
 --
--- Name: django_content_type; Type: TABLE; Schema: public; Owner: postgres
+-- Name: django_content_type; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.django_content_type (
@@ -1381,10 +1477,10 @@ CREATE TABLE public.django_content_type (
 );
 
 
-ALTER TABLE public.django_content_type OWNER TO postgres;
+ALTER TABLE public.django_content_type OWNER TO kokuadmin;
 
 --
--- Name: django_content_type_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: django_content_type_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.django_content_type_id_seq
@@ -1395,17 +1491,17 @@ CREATE SEQUENCE public.django_content_type_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.django_content_type_id_seq OWNER TO postgres;
+ALTER TABLE public.django_content_type_id_seq OWNER TO kokuadmin;
 
 --
--- Name: django_content_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: django_content_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.django_content_type_id_seq OWNED BY public.django_content_type.id;
 
 
 --
--- Name: django_migrations; Type: TABLE; Schema: public; Owner: postgres
+-- Name: django_migrations; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.django_migrations (
@@ -1416,10 +1512,10 @@ CREATE TABLE public.django_migrations (
 );
 
 
-ALTER TABLE public.django_migrations OWNER TO postgres;
+ALTER TABLE public.django_migrations OWNER TO kokuadmin;
 
 --
--- Name: django_migrations_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: django_migrations_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.django_migrations_id_seq
@@ -1430,17 +1526,17 @@ CREATE SEQUENCE public.django_migrations_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.django_migrations_id_seq OWNER TO postgres;
+ALTER TABLE public.django_migrations_id_seq OWNER TO kokuadmin;
 
 --
--- Name: django_migrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: django_migrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.django_migrations_id_seq OWNED BY public.django_migrations.id;
 
 
 --
--- Name: django_session; Type: TABLE; Schema: public; Owner: postgres
+-- Name: django_session; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.django_session (
@@ -1450,10 +1546,10 @@ CREATE TABLE public.django_session (
 );
 
 
-ALTER TABLE public.django_session OWNER TO postgres;
+ALTER TABLE public.django_session OWNER TO kokuadmin;
 
 --
--- Name: region_mapping; Type: TABLE; Schema: public; Owner: postgres
+-- Name: region_mapping; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.region_mapping (
@@ -1463,10 +1559,10 @@ CREATE TABLE public.region_mapping (
 );
 
 
-ALTER TABLE public.region_mapping OWNER TO postgres;
+ALTER TABLE public.region_mapping OWNER TO kokuadmin;
 
 --
--- Name: region_mapping_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: region_mapping_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.region_mapping_id_seq
@@ -1477,17 +1573,17 @@ CREATE SEQUENCE public.region_mapping_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.region_mapping_id_seq OWNER TO postgres;
+ALTER TABLE public.region_mapping_id_seq OWNER TO kokuadmin;
 
 --
--- Name: region_mapping_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: region_mapping_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.region_mapping_id_seq OWNED BY public.region_mapping.id;
 
 
 --
--- Name: reporting_common_costusagereportmanifest; Type: TABLE; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.reporting_common_costusagereportmanifest (
@@ -1502,10 +1598,10 @@ CREATE TABLE public.reporting_common_costusagereportmanifest (
 );
 
 
-ALTER TABLE public.reporting_common_costusagereportmanifest OWNER TO postgres;
+ALTER TABLE public.reporting_common_costusagereportmanifest OWNER TO kokuadmin;
 
 --
--- Name: reporting_common_costusagereportmanifest_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.reporting_common_costusagereportmanifest_id_seq
@@ -1516,17 +1612,17 @@ CREATE SEQUENCE public.reporting_common_costusagereportmanifest_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.reporting_common_costusagereportmanifest_id_seq OWNER TO postgres;
+ALTER TABLE public.reporting_common_costusagereportmanifest_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_common_costusagereportmanifest_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.reporting_common_costusagereportmanifest_id_seq OWNED BY public.reporting_common_costusagereportmanifest.id;
 
 
 --
--- Name: reporting_common_costusagereportstatus; Type: TABLE; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.reporting_common_costusagereportstatus (
@@ -1539,10 +1635,10 @@ CREATE TABLE public.reporting_common_costusagereportstatus (
 );
 
 
-ALTER TABLE public.reporting_common_costusagereportstatus OWNER TO postgres;
+ALTER TABLE public.reporting_common_costusagereportstatus OWNER TO kokuadmin;
 
 --
--- Name: reporting_common_costusagereportstatus_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.reporting_common_costusagereportstatus_id_seq
@@ -1553,17 +1649,17 @@ CREATE SEQUENCE public.reporting_common_costusagereportstatus_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.reporting_common_costusagereportstatus_id_seq OWNER TO postgres;
+ALTER TABLE public.reporting_common_costusagereportstatus_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_common_costusagereportstatus_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.reporting_common_costusagereportstatus_id_seq OWNED BY public.reporting_common_costusagereportstatus.id;
 
 
 --
--- Name: reporting_common_reportcolumnmap; Type: TABLE; Schema: public; Owner: postgres
+-- Name: reporting_common_reportcolumnmap; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.reporting_common_reportcolumnmap (
@@ -1575,10 +1671,10 @@ CREATE TABLE public.reporting_common_reportcolumnmap (
 );
 
 
-ALTER TABLE public.reporting_common_reportcolumnmap OWNER TO postgres;
+ALTER TABLE public.reporting_common_reportcolumnmap OWNER TO kokuadmin;
 
 --
--- Name: reporting_common_reportcolumnmap_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: reporting_common_reportcolumnmap_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.reporting_common_reportcolumnmap_id_seq
@@ -1589,17 +1685,17 @@ CREATE SEQUENCE public.reporting_common_reportcolumnmap_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.reporting_common_reportcolumnmap_id_seq OWNER TO postgres;
+ALTER TABLE public.reporting_common_reportcolumnmap_id_seq OWNER TO kokuadmin;
 
 --
--- Name: reporting_common_reportcolumnmap_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: reporting_common_reportcolumnmap_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.reporting_common_reportcolumnmap_id_seq OWNED BY public.reporting_common_reportcolumnmap.id;
 
 
 --
--- Name: si_unit_scale; Type: TABLE; Schema: public; Owner: postgres
+-- Name: si_unit_scale; Type: TABLE; Schema: public; Owner: kokuadmin
 --
 
 CREATE TABLE public.si_unit_scale (
@@ -1610,10 +1706,10 @@ CREATE TABLE public.si_unit_scale (
 );
 
 
-ALTER TABLE public.si_unit_scale OWNER TO postgres;
+ALTER TABLE public.si_unit_scale OWNER TO kokuadmin;
 
 --
--- Name: si_unit_scale_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: si_unit_scale_id_seq; Type: SEQUENCE; Schema: public; Owner: kokuadmin
 --
 
 CREATE SEQUENCE public.si_unit_scale_id_seq
@@ -1624,353 +1720,362 @@ CREATE SEQUENCE public.si_unit_scale_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.si_unit_scale_id_seq OWNER TO postgres;
+ALTER TABLE public.si_unit_scale_id_seq OWNER TO kokuadmin;
 
 --
--- Name: si_unit_scale_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: si_unit_scale_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kokuadmin
 --
 
 ALTER SEQUENCE public.si_unit_scale_id_seq OWNED BY public.si_unit_scale.id;
 
 
 --
--- Name: django_migrations id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: django_migrations id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.django_migrations ALTER COLUMN id SET DEFAULT nextval('acct10001.django_migrations_id_seq'::regclass);
 
 
 --
--- Name: rates_rate id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: rates_rate id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.rates_rate ALTER COLUMN id SET DEFAULT nextval('acct10001.rates_rate_id_seq'::regclass);
 
 
 --
--- Name: reporting_awsaccountalias id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awsaccountalias id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awsaccountalias ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awsaccountalias_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentry id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentry id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentry ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentry_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentrybill id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrybill id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrybill ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentrybill_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentrylineitem id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentrylineitem_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentrylineitem_aggregates id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_aggregates id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_aggregates ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentrylineitem_aggregates_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentrylineitem_daily id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentrylineitem_daily_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentrylineitem_daily_summary id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_summary id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily_summary ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentrylineitem_daily_summary_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentrypricing id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrypricing id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrypricing ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentrypricing_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentryproduct id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryproduct id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentryproduct ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentryproduct_id_seq'::regclass);
 
 
 --
--- Name: reporting_awscostentryreservation id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryreservation id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentryreservation ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_awscostentryreservation_id_seq'::regclass);
 
 
 --
--- Name: reporting_ocpusagelineitem id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpawscostlineitem_daily_summary id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
+--
+
+ALTER TABLE ONLY acct10001.reporting_ocpawscostlineitem_daily_summary ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_ocpawscostlineitem_daily_summary_id_seq'::regclass);
+
+
+--
+-- Name: reporting_ocpusagelineitem id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_ocpusagelineitem_id_seq'::regclass);
 
 
 --
--- Name: reporting_ocpusagelineitem_aggregates id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_aggregates id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_aggregates ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_ocpusagelineitem_aggregates_id_seq'::regclass);
 
 
 --
--- Name: reporting_ocpusagelineitem_daily id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_daily ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_ocpusagelineitem_daily_id_seq'::regclass);
 
 
 --
--- Name: reporting_ocpusagelineitem_daily_summary id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily_summary id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_daily_summary ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_ocpusagelineitem_daily_summary_id_seq'::regclass);
 
 
 --
--- Name: reporting_ocpusagereport id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagereport ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_ocpusagereport_id_seq'::regclass);
 
 
 --
--- Name: reporting_ocpusagereportperiod id; Type: DEFAULT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereportperiod id; Type: DEFAULT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagereportperiod ALTER COLUMN id SET DEFAULT nextval('acct10001.reporting_ocpusagereportperiod_id_seq'::regclass);
 
 
 --
--- Name: api_customer id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: api_customer id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_customer ALTER COLUMN id SET DEFAULT nextval('public.api_customer_id_seq'::regclass);
 
 
 --
--- Name: api_provider id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: api_provider id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_provider ALTER COLUMN id SET DEFAULT nextval('public.api_provider_id_seq'::regclass);
 
 
 --
--- Name: api_providerauthentication id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: api_providerauthentication id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_providerauthentication ALTER COLUMN id SET DEFAULT nextval('public.api_providerauthentication_id_seq'::regclass);
 
 
 --
--- Name: api_providerbillingsource id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: api_providerbillingsource id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_providerbillingsource ALTER COLUMN id SET DEFAULT nextval('public.api_providerbillingsource_id_seq'::regclass);
 
 
 --
--- Name: api_tenant id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: api_tenant id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_tenant ALTER COLUMN id SET DEFAULT nextval('public.api_tenant_id_seq'::regclass);
 
 
 --
--- Name: api_user id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: api_user id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_user ALTER COLUMN id SET DEFAULT nextval('public.api_user_id_seq'::regclass);
 
 
 --
--- Name: api_userpreference id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: api_userpreference id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_userpreference ALTER COLUMN id SET DEFAULT nextval('public.api_userpreference_id_seq'::regclass);
 
 
 --
--- Name: auth_group id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: auth_group id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_group ALTER COLUMN id SET DEFAULT nextval('public.auth_group_id_seq'::regclass);
 
 
 --
--- Name: auth_group_permissions id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: auth_group_permissions id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_group_permissions ALTER COLUMN id SET DEFAULT nextval('public.auth_group_permissions_id_seq'::regclass);
 
 
 --
--- Name: auth_permission id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: auth_permission id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_permission ALTER COLUMN id SET DEFAULT nextval('public.auth_permission_id_seq'::regclass);
 
 
 --
--- Name: auth_user id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: auth_user id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user ALTER COLUMN id SET DEFAULT nextval('public.auth_user_id_seq'::regclass);
 
 
 --
--- Name: auth_user_groups id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: auth_user_groups id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_groups ALTER COLUMN id SET DEFAULT nextval('public.auth_user_groups_id_seq'::regclass);
 
 
 --
--- Name: auth_user_user_permissions id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_user_permissions ALTER COLUMN id SET DEFAULT nextval('public.auth_user_user_permissions_id_seq'::regclass);
 
 
 --
--- Name: django_admin_log id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: django_admin_log id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_admin_log ALTER COLUMN id SET DEFAULT nextval('public.django_admin_log_id_seq'::regclass);
 
 
 --
--- Name: django_content_type id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: django_content_type id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_content_type ALTER COLUMN id SET DEFAULT nextval('public.django_content_type_id_seq'::regclass);
 
 
 --
--- Name: django_migrations id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: django_migrations id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_migrations ALTER COLUMN id SET DEFAULT nextval('public.django_migrations_id_seq'::regclass);
 
 
 --
--- Name: region_mapping id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: region_mapping id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.region_mapping ALTER COLUMN id SET DEFAULT nextval('public.region_mapping_id_seq'::regclass);
 
 
 --
--- Name: reporting_common_costusagereportmanifest id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_costusagereportmanifest ALTER COLUMN id SET DEFAULT nextval('public.reporting_common_costusagereportmanifest_id_seq'::regclass);
 
 
 --
--- Name: reporting_common_costusagereportstatus id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_costusagereportstatus ALTER COLUMN id SET DEFAULT nextval('public.reporting_common_costusagereportstatus_id_seq'::regclass);
 
 
 --
--- Name: reporting_common_reportcolumnmap id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: reporting_common_reportcolumnmap id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_reportcolumnmap ALTER COLUMN id SET DEFAULT nextval('public.reporting_common_reportcolumnmap_id_seq'::regclass);
 
 
 --
--- Name: si_unit_scale id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: si_unit_scale id; Type: DEFAULT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.si_unit_scale ALTER COLUMN id SET DEFAULT nextval('public.si_unit_scale_id_seq'::regclass);
 
 
 --
--- Data for Name: django_migrations; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: django_migrations; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.django_migrations (id, app, name, applied) FROM stdin;
-1	contenttypes	0001_initial	2019-01-30 18:00:54.546731+00
-2	auth	0001_initial	2019-01-30 18:00:54.563887+00
-3	admin	0001_initial	2019-01-30 18:00:54.57802+00
-4	admin	0002_logentry_remove_auto_add	2019-01-30 18:00:54.592879+00
-5	admin	0003_logentry_add_action_flag_choices	2019-01-30 18:00:54.634534+00
-6	api	0001_initial	2019-01-30 18:00:54.686887+00
-7	api	0002_auto_20180926_1905	2019-01-30 18:00:54.698114+00
-8	api	0003_auto_20181008_1819	2019-01-30 18:00:54.726904+00
-9	api	0004_auto_20181012_1507	2019-01-30 18:00:54.738108+00
-10	api	0005_auto_20181109_2121	2019-01-30 18:00:54.746894+00
-11	api	0006_delete_rate	2019-01-30 18:00:54.752026+00
-12	api	0007_auto_20181213_1940	2019-01-30 18:00:54.772382+00
-13	contenttypes	0002_remove_content_type_name	2019-01-30 18:00:54.789715+00
-14	auth	0002_alter_permission_name_max_length	2019-01-30 18:00:54.79759+00
-15	auth	0003_alter_user_email_max_length	2019-01-30 18:00:54.812824+00
-16	auth	0004_alter_user_username_opts	2019-01-30 18:00:54.825549+00
-17	auth	0005_alter_user_last_login_null	2019-01-30 18:00:54.838016+00
-18	auth	0006_require_contenttypes_0002	2019-01-30 18:00:54.841923+00
-19	auth	0007_alter_validators_add_error_messages	2019-01-30 18:00:54.855701+00
-20	auth	0008_alter_user_username_max_length	2019-01-30 18:00:54.868448+00
-21	auth	0009_alter_user_last_name_max_length	2019-01-30 18:00:54.880992+00
-22	rates	0001_initial	2019-01-30 18:00:54.902783+00
-23	rates	0002_auto_20181205_1810	2019-01-30 18:00:54.909133+00
-24	reporting	0001_initial	2019-01-30 18:00:55.2558+00
-25	reporting	0002_auto_20180926_1818	2019-01-30 18:00:55.396509+00
-26	reporting	0003_auto_20180928_1840	2019-01-30 18:00:55.469227+00
-27	reporting	0004_auto_20181003_1633	2019-01-30 18:00:55.592848+00
-28	reporting	0005_auto_20181003_1416	2019-01-30 18:00:55.61994+00
-29	reporting	0006_awscostentrylineitemaggregates_account_alias	2019-01-30 18:00:55.635179+00
-30	reporting	0007_awscostentrybill_provider_id	2019-01-30 18:00:55.645921+00
-31	reporting	0008_auto_20181012_1724	2019-01-30 18:00:55.658647+00
-32	reporting	0009_auto_20181016_1940	2019-01-30 18:00:55.737945+00
-33	reporting	0010_auto_20181017_1659	2019-01-30 18:00:55.954675+00
-34	reporting	0011_auto_20181018_1811	2019-01-30 18:00:56.084251+00
-35	reporting	0012_auto_20181106_1502	2019-01-30 18:00:56.110853+00
-36	reporting	0013_auto_20181107_1956	2019-01-30 18:00:56.297043+00
-37	reporting	0014_auto_20181108_0207	2019-01-30 18:00:56.323184+00
-38	reporting	0015_auto_20181109_1618	2019-01-30 18:00:56.336457+00
-39	reporting	0016_delete_rate	2019-01-30 18:00:56.344594+00
-40	reporting	0017_auto_20181121_1444	2019-01-30 18:00:56.387649+00
-41	reporting	0018_auto_20181129_0217	2019-01-30 18:00:56.546904+00
-42	reporting	0019_auto_20181206_2138	2019-01-30 18:00:56.569937+00
-43	reporting	0020_auto_20181211_1557	2019-01-30 18:00:56.602198+00
-44	reporting	0021_auto_20181212_1816	2019-01-30 18:00:56.639046+00
-45	reporting	0022_auto_20181221_1617	2019-01-30 18:00:56.654168+00
-46	reporting	0023_awscostentrylineitemdailysummary_tags	2019-01-30 18:00:56.665955+00
-47	reporting	0024_ocpusagepodlabelsummary	2019-01-30 18:00:56.681651+00
-48	reporting	0025_auto_20190128_1825	2019-01-30 18:00:56.713289+00
-49	reporting	0026_auto_20190130_1746	2019-01-30 18:00:56.785888+00
-50	reporting_common	0001_initial	2019-01-30 18:00:56.809003+00
-51	reporting_common	0002_auto_20180926_1905	2019-01-30 18:00:56.819513+00
-52	reporting_common	0003_auto_20180928_1732	2019-01-30 18:00:56.825679+00
-53	reporting_common	0004_auto_20181003_1859	2019-01-30 18:00:56.866259+00
-54	reporting_common	0005_auto_20181127_2046	2019-01-30 18:00:56.872141+00
-55	sessions	0001_initial	2019-01-30 18:00:56.879941+00
+1	contenttypes	0001_initial	2019-02-05 20:55:20.818078+00
+2	auth	0001_initial	2019-02-05 20:55:20.834991+00
+3	admin	0001_initial	2019-02-05 20:55:20.848827+00
+4	admin	0002_logentry_remove_auto_add	2019-02-05 20:55:20.861555+00
+5	admin	0003_logentry_add_action_flag_choices	2019-02-05 20:55:20.874325+00
+6	api	0001_initial	2019-02-05 20:55:20.910694+00
+7	api	0002_auto_20180926_1905	2019-02-05 20:55:20.92078+00
+8	api	0003_auto_20181008_1819	2019-02-05 20:55:20.940168+00
+9	api	0004_auto_20181012_1507	2019-02-05 20:55:20.952305+00
+10	api	0005_auto_20181109_2121	2019-02-05 20:55:20.960453+00
+11	api	0006_delete_rate	2019-02-05 20:55:20.965948+00
+12	api	0007_auto_20181213_1940	2019-02-05 20:55:20.982976+00
+13	contenttypes	0002_remove_content_type_name	2019-02-05 20:55:20.997512+00
+14	auth	0002_alter_permission_name_max_length	2019-02-05 20:55:21.006105+00
+15	auth	0003_alter_user_email_max_length	2019-02-05 20:55:21.016857+00
+16	auth	0004_alter_user_username_opts	2019-02-05 20:55:21.027836+00
+17	auth	0005_alter_user_last_login_null	2019-02-05 20:55:21.038848+00
+18	auth	0006_require_contenttypes_0002	2019-02-05 20:55:21.043486+00
+19	auth	0007_alter_validators_add_error_messages	2019-02-05 20:55:21.054983+00
+20	auth	0008_alter_user_username_max_length	2019-02-05 20:55:21.068472+00
+21	auth	0009_alter_user_last_name_max_length	2019-02-05 20:55:21.080355+00
+22	rates	0001_initial	2019-02-05 20:55:21.103715+00
+23	rates	0002_auto_20181205_1810	2019-02-05 20:55:21.110615+00
+24	reporting	0001_initial	2019-02-05 20:55:21.444077+00
+25	reporting	0002_auto_20180926_1818	2019-02-05 20:55:21.595394+00
+26	reporting	0003_auto_20180928_1840	2019-02-05 20:55:21.664429+00
+27	reporting	0004_auto_20181003_1633	2019-02-05 20:55:21.803114+00
+28	reporting	0005_auto_20181003_1416	2019-02-05 20:55:21.82924+00
+29	reporting	0006_awscostentrylineitemaggregates_account_alias	2019-02-05 20:55:21.847335+00
+30	reporting	0007_awscostentrybill_provider_id	2019-02-05 20:55:21.859377+00
+31	reporting	0008_auto_20181012_1724	2019-02-05 20:55:21.874203+00
+32	reporting	0009_auto_20181016_1940	2019-02-05 20:55:21.928636+00
+33	reporting	0010_auto_20181017_1659	2019-02-05 20:55:22.146842+00
+34	reporting	0011_auto_20181018_1811	2019-02-05 20:55:22.259732+00
+35	reporting	0012_auto_20181106_1502	2019-02-05 20:55:22.280617+00
+36	reporting	0013_auto_20181107_1956	2019-02-05 20:55:22.365432+00
+37	reporting	0014_auto_20181108_0207	2019-02-05 20:55:22.379129+00
+38	reporting	0015_auto_20181109_1618	2019-02-05 20:55:22.386039+00
+39	reporting	0016_delete_rate	2019-02-05 20:55:22.392507+00
+40	reporting	0017_auto_20181121_1444	2019-02-05 20:55:22.425844+00
+41	reporting	0018_auto_20181129_0217	2019-02-05 20:55:22.550578+00
+42	reporting	0019_auto_20181206_2138	2019-02-05 20:55:22.573515+00
+43	reporting	0020_auto_20181211_1557	2019-02-05 20:55:22.60142+00
+44	reporting	0021_auto_20181212_1816	2019-02-05 20:55:22.631933+00
+45	reporting	0022_auto_20181221_1617	2019-02-05 20:55:22.644899+00
+46	reporting	0023_awscostentrylineitemdailysummary_tags	2019-02-05 20:55:22.654996+00
+47	reporting	0024_ocpusagepodlabelsummary	2019-02-05 20:55:22.670463+00
+48	reporting	0025_auto_20190128_1825	2019-02-05 20:55:22.693534+00
+49	reporting	0026_auto_20190130_1746	2019-02-05 20:55:22.730595+00
+50	reporting	0027_auto_20190205_1659	2019-02-05 20:55:22.741141+00
+51	reporting	0028_auto_20190205_2022	2019-02-05 20:55:22.805664+00
+52	reporting_common	0001_initial	2019-02-05 20:55:22.821906+00
+53	reporting_common	0002_auto_20180926_1905	2019-02-05 20:55:22.829872+00
+54	reporting_common	0003_auto_20180928_1732	2019-02-05 20:55:22.834835+00
+55	reporting_common	0004_auto_20181003_1859	2019-02-05 20:55:22.866199+00
+56	reporting_common	0005_auto_20181127_2046	2019-02-05 20:55:22.871777+00
+57	sessions	0001_initial	2019-02-05 20:55:22.877834+00
 \.
 
 
 --
--- Data for Name: rates_rate; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: rates_rate; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.rates_rate (id, uuid, provider_uuid, metric, rates) FROM stdin;
@@ -1978,7 +2083,7 @@ COPY acct10001.rates_rate (id, uuid, provider_uuid, metric, rates) FROM stdin;
 
 
 --
--- Data for Name: reporting_awsaccountalias; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awsaccountalias; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awsaccountalias (id, account_id, account_alias) FROM stdin;
@@ -1986,7 +2091,7 @@ COPY acct10001.reporting_awsaccountalias (id, account_id, account_alias) FROM st
 
 
 --
--- Data for Name: reporting_awscostentry; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentry; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentry (id, interval_start, interval_end, bill_id) FROM stdin;
@@ -1994,7 +2099,7 @@ COPY acct10001.reporting_awscostentry (id, interval_start, interval_end, bill_id
 
 
 --
--- Data for Name: reporting_awscostentrybill; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentrybill; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentrybill (id, billing_resource, bill_type, payer_account_id, billing_period_start, billing_period_end, finalized_datetime, summary_data_creation_datetime, summary_data_updated_datetime, provider_id) FROM stdin;
@@ -2002,7 +2107,7 @@ COPY acct10001.reporting_awscostentrybill (id, billing_resource, bill_type, paye
 
 
 --
--- Data for Name: reporting_awscostentrylineitem; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentrylineitem; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentrylineitem (id, hash, tags, invoice_id, line_item_type, usage_account_id, usage_start, usage_end, product_code, usage_type, operation, availability_zone, resource_id, usage_amount, normalization_factor, normalized_usage_amount, currency_code, unblended_rate, unblended_cost, blended_rate, blended_cost, public_on_demand_cost, public_on_demand_rate, reservation_amortized_upfront_fee, reservation_amortized_upfront_cost_for_usage, reservation_recurring_fee_for_usage, reservation_unused_quantity, reservation_unused_recurring_fee, tax_type, cost_entry_id, cost_entry_bill_id, cost_entry_pricing_id, cost_entry_product_id, cost_entry_reservation_id) FROM stdin;
@@ -2010,7 +2115,7 @@ COPY acct10001.reporting_awscostentrylineitem (id, hash, tags, invoice_id, line_
 
 
 --
--- Data for Name: reporting_awscostentrylineitem_aggregates; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentrylineitem_aggregates; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentrylineitem_aggregates (id, time_scope_value, report_type, usage_account_id, product_code, region, availability_zone, usage_amount, unblended_cost, resource_count, account_alias_id, tags) FROM stdin;
@@ -2018,7 +2123,7 @@ COPY acct10001.reporting_awscostentrylineitem_aggregates (id, time_scope_value, 
 
 
 --
--- Data for Name: reporting_awscostentrylineitem_daily; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentrylineitem_daily; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentrylineitem_daily (id, line_item_type, usage_account_id, usage_start, usage_end, product_code, usage_type, operation, availability_zone, resource_id, usage_amount, normalization_factor, normalized_usage_amount, currency_code, unblended_rate, unblended_cost, blended_rate, blended_cost, public_on_demand_cost, public_on_demand_rate, tax_type, tags, cost_entry_pricing_id, cost_entry_product_id, cost_entry_reservation_id) FROM stdin;
@@ -2026,7 +2131,7 @@ COPY acct10001.reporting_awscostentrylineitem_daily (id, line_item_type, usage_a
 
 
 --
--- Data for Name: reporting_awscostentrylineitem_daily_summary; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentrylineitem_daily_summary; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentrylineitem_daily_summary (id, usage_start, usage_end, usage_account_id, product_code, product_family, availability_zone, region, instance_type, unit, resource_count, usage_amount, normalization_factor, normalized_usage_amount, currency_code, unblended_rate, unblended_cost, blended_rate, blended_cost, public_on_demand_cost, public_on_demand_rate, tax_type, account_alias_id, tags) FROM stdin;
@@ -2034,7 +2139,7 @@ COPY acct10001.reporting_awscostentrylineitem_daily_summary (id, usage_start, us
 
 
 --
--- Data for Name: reporting_awscostentrypricing; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentrypricing; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentrypricing (id, term, unit) FROM stdin;
@@ -2042,7 +2147,7 @@ COPY acct10001.reporting_awscostentrypricing (id, term, unit) FROM stdin;
 
 
 --
--- Data for Name: reporting_awscostentryproduct; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentryproduct; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentryproduct (id, sku, product_name, product_family, service_code, region, instance_type, memory, memory_unit, vcpu) FROM stdin;
@@ -2050,7 +2155,7 @@ COPY acct10001.reporting_awscostentryproduct (id, sku, product_name, product_fam
 
 
 --
--- Data for Name: reporting_awscostentryreservation; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awscostentryreservation; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awscostentryreservation (id, reservation_arn, number_of_reservations, units_per_reservation, start_time, end_time) FROM stdin;
@@ -2058,7 +2163,7 @@ COPY acct10001.reporting_awscostentryreservation (id, reservation_arn, number_of
 
 
 --
--- Data for Name: reporting_awstags_summary; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_awstags_summary; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_awstags_summary (key, "values") FROM stdin;
@@ -2066,7 +2171,15 @@ COPY acct10001.reporting_awstags_summary (key, "values") FROM stdin;
 
 
 --
--- Data for Name: reporting_ocpusagelineitem; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_ocpawscostlineitem_daily_summary; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
+--
+
+COPY acct10001.reporting_ocpawscostlineitem_daily_summary (id, cluster_id, cluster_alias, namespace, pod, node, resource_id, usage_start, usage_end, pod_labels, product_code, product_family, usage_account_id, availability_zone, region, unit, tags, unblended_cost, pod_cost, account_alias_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: reporting_ocpusagelineitem; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_ocpusagelineitem (id, namespace, pod, node, pod_usage_cpu_core_seconds, pod_limit_cpu_core_seconds, report_id, report_period_id, pod_limit_memory_byte_seconds, pod_request_cpu_core_seconds, pod_request_memory_byte_seconds, pod_usage_memory_byte_seconds, node_capacity_cpu_core_seconds, node_capacity_cpu_cores, node_capacity_memory_byte_seconds, node_capacity_memory_bytes, pod_labels, resource_id) FROM stdin;
@@ -2074,7 +2187,7 @@ COPY acct10001.reporting_ocpusagelineitem (id, namespace, pod, node, pod_usage_c
 
 
 --
--- Data for Name: reporting_ocpusagelineitem_aggregates; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_ocpusagelineitem_aggregates; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_ocpusagelineitem_aggregates (id, time_scope_value, cluster_id, namespace, pod, node, pod_usage_cpu_core_hours, pod_request_cpu_core_hours, pod_limit_cpu_core_hours, pod_usage_memory_gigabytes, pod_request_memory_gigabytes, pod_limit_memory_gigabytes, node_capacity_cpu_core_hours, node_capacity_cpu_cores, node_capacity_memory_byte_hours, node_capacity_memory_bytes, resource_id) FROM stdin;
@@ -2082,7 +2195,7 @@ COPY acct10001.reporting_ocpusagelineitem_aggregates (id, time_scope_value, clus
 
 
 --
--- Data for Name: reporting_ocpusagelineitem_daily; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_ocpusagelineitem_daily; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_ocpusagelineitem_daily (id, namespace, pod, node, usage_start, usage_end, pod_usage_cpu_core_seconds, pod_limit_cpu_core_seconds, pod_limit_memory_byte_seconds, pod_request_cpu_core_seconds, pod_request_memory_byte_seconds, pod_usage_memory_byte_seconds, cluster_id, total_seconds, node_capacity_cpu_core_seconds, node_capacity_cpu_cores, node_capacity_memory_byte_seconds, node_capacity_memory_bytes, pod_labels, cluster_capacity_cpu_core_seconds, cluster_capacity_memory_byte_seconds, cluster_alias, resource_id) FROM stdin;
@@ -2090,7 +2203,7 @@ COPY acct10001.reporting_ocpusagelineitem_daily (id, namespace, pod, node, usage
 
 
 --
--- Data for Name: reporting_ocpusagelineitem_daily_summary; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_ocpusagelineitem_daily_summary; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_ocpusagelineitem_daily_summary (id, cluster_id, namespace, pod, node, usage_start, usage_end, pod_usage_cpu_core_hours, pod_request_cpu_core_hours, pod_limit_cpu_core_hours, pod_usage_memory_gigabyte_hours, pod_request_memory_gigabyte_hours, pod_limit_memory_gigabyte_hours, node_capacity_cpu_core_hours, node_capacity_cpu_cores, pod_charge_cpu_core_hours, pod_charge_memory_gigabyte_hours, node_capacity_memory_gigabyte_hours, node_capacity_memory_gigabytes, cluster_capacity_cpu_core_hours, cluster_capacity_memory_gigabyte_hours, pod_labels, cluster_alias, resource_id) FROM stdin;
@@ -2098,7 +2211,7 @@ COPY acct10001.reporting_ocpusagelineitem_daily_summary (id, cluster_id, namespa
 
 
 --
--- Data for Name: reporting_ocpusagepodlabel_summary; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_ocpusagepodlabel_summary; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_ocpusagepodlabel_summary (key, "values") FROM stdin;
@@ -2106,7 +2219,7 @@ COPY acct10001.reporting_ocpusagepodlabel_summary (key, "values") FROM stdin;
 
 
 --
--- Data for Name: reporting_ocpusagereport; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_ocpusagereport; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_ocpusagereport (id, interval_start, interval_end, report_period_id) FROM stdin;
@@ -2114,7 +2227,7 @@ COPY acct10001.reporting_ocpusagereport (id, interval_start, interval_end, repor
 
 
 --
--- Data for Name: reporting_ocpusagereportperiod; Type: TABLE DATA; Schema: acct10001; Owner: postgres
+-- Data for Name: reporting_ocpusagereportperiod; Type: TABLE DATA; Schema: acct10001; Owner: kokuadmin
 --
 
 COPY acct10001.reporting_ocpusagereportperiod (id, cluster_id, report_period_start, report_period_end, provider_id, summary_data_creation_datetime, summary_data_updated_datetime) FROM stdin;
@@ -2122,16 +2235,16 @@ COPY acct10001.reporting_ocpusagereportperiod (id, cluster_id, report_period_sta
 
 
 --
--- Data for Name: api_customer; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: api_customer; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.api_customer (id, date_created, uuid, account_id, schema_name) FROM stdin;
-1	2019-01-30 18:00:54.434227+00	d3ef4912-f3fd-4c3b-bcfb-56ebb341d908	10001	acct10001
+1	2019-02-05 20:55:20.772662+00	9b1abeb9-5021-4085-9bf5-5ef4e25d1a1f	10001	acct10001
 \.
 
 
 --
--- Data for Name: api_provider; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: api_provider; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.api_provider (id, uuid, name, type, setup_complete, authentication_id, billing_source_id, created_by_id, customer_id) FROM stdin;
@@ -2141,7 +2254,7 @@ COPY public.api_provider (id, uuid, name, type, setup_complete, authentication_i
 
 
 --
--- Data for Name: api_providerauthentication; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: api_providerauthentication; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.api_providerauthentication (id, uuid, provider_resource_name) FROM stdin;
@@ -2151,7 +2264,7 @@ COPY public.api_providerauthentication (id, uuid, provider_resource_name) FROM s
 
 
 --
--- Data for Name: api_providerbillingsource; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: api_providerbillingsource; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.api_providerbillingsource (id, uuid, bucket) FROM stdin;
@@ -2160,7 +2273,7 @@ COPY public.api_providerbillingsource (id, uuid, bucket) FROM stdin;
 
 
 --
--- Data for Name: api_tenant; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: api_tenant; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.api_tenant (id, schema_name) FROM stdin;
@@ -2169,27 +2282,27 @@ COPY public.api_tenant (id, schema_name) FROM stdin;
 
 
 --
--- Data for Name: api_user; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: api_user; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.api_user (id, uuid, username, email, date_created, is_active, customer_id) FROM stdin;
-1	535ca83f-8b33-4859-9a35-4ae5b5bbffb1	user_dev	user_dev@foo.com	2019-01-30 18:00:56.947482+00	t	1
+1	d03dc491-f686-4dc3-85aa-b035766ad83b	user_dev	user_dev@foo.com	2019-02-05 20:55:22.94736+00	t	1
 \.
 
 
 --
--- Data for Name: api_userpreference; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: api_userpreference; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.api_userpreference (id, uuid, preference, name, description, user_id) FROM stdin;
-1	6dd6fa9e-aa31-4f95-a49c-1368fe0adb65	{"currency": "USD"}	currency	default preference	1
-2	ea064109-1c07-4115-a129-949e5e4aa0c7	{"timezone": "UTC"}	timezone	default preference	1
-3	6456448b-dbb7-4c5b-a802-6e9bfcab1209	{"locale": "en_US.UTF-8"}	locale	default preference	1
+1	8482c75d-ba16-4ecd-a87d-de4b731727e8	{"currency": "USD"}	currency	default preference	1
+2	1d9cacf3-5077-4d3e-aeb5-d3eec86caf5d	{"timezone": "UTC"}	timezone	default preference	1
+3	084327d5-a190-4487-aaed-ac381c89b13c	{"locale": "en_US.UTF-8"}	locale	default preference	1
 \.
 
 
 --
--- Data for Name: auth_group; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: auth_group; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.auth_group (id, name) FROM stdin;
@@ -2197,7 +2310,7 @@ COPY public.auth_group (id, name) FROM stdin;
 
 
 --
--- Data for Name: auth_group_permissions; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: auth_group_permissions; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.auth_group_permissions (id, group_id, permission_id) FROM stdin;
@@ -2205,7 +2318,7 @@ COPY public.auth_group_permissions (id, group_id, permission_id) FROM stdin;
 
 
 --
--- Data for Name: auth_permission; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: auth_permission; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.auth_permission (id, name, content_type_id, codename) FROM stdin;
@@ -2333,35 +2446,43 @@ COPY public.auth_permission (id, name, content_type_id, codename) FROM stdin;
 122	Can change aws tags summary	31	change_awstagssummary
 123	Can delete aws tags summary	31	delete_awstagssummary
 124	Can view aws tags summary	31	view_awstagssummary
-125	Can add cost usage report status	32	add_costusagereportstatus
-126	Can change cost usage report status	32	change_costusagereportstatus
-127	Can delete cost usage report status	32	delete_costusagereportstatus
-128	Can view cost usage report status	32	view_costusagereportstatus
-129	Can add region mapping	33	add_regionmapping
-130	Can change region mapping	33	change_regionmapping
-131	Can delete region mapping	33	delete_regionmapping
-132	Can view region mapping	33	view_regionmapping
-133	Can add report column map	34	add_reportcolumnmap
-134	Can change report column map	34	change_reportcolumnmap
-135	Can delete report column map	34	delete_reportcolumnmap
-136	Can view report column map	34	view_reportcolumnmap
-137	Can add si unit scale	35	add_siunitscale
-138	Can change si unit scale	35	change_siunitscale
-139	Can delete si unit scale	35	delete_siunitscale
-140	Can view si unit scale	35	view_siunitscale
-141	Can add cost usage report manifest	36	add_costusagereportmanifest
-142	Can change cost usage report manifest	36	change_costusagereportmanifest
-143	Can delete cost usage report manifest	36	delete_costusagereportmanifest
-144	Can view cost usage report manifest	36	view_costusagereportmanifest
-145	Can add rate	37	add_rate
-146	Can change rate	37	change_rate
-147	Can delete rate	37	delete_rate
-148	Can view rate	37	view_rate
+125	Can add ocpaws cost line item daily	32	add_ocpawscostlineitemdaily
+126	Can change ocpaws cost line item daily	32	change_ocpawscostlineitemdaily
+127	Can delete ocpaws cost line item daily	32	delete_ocpawscostlineitemdaily
+128	Can view ocpaws cost line item daily	32	view_ocpawscostlineitemdaily
+129	Can add ocpaws cost line item daily summary	33	add_ocpawscostlineitemdailysummary
+130	Can change ocpaws cost line item daily summary	33	change_ocpawscostlineitemdailysummary
+131	Can delete ocpaws cost line item daily summary	33	delete_ocpawscostlineitemdailysummary
+132	Can view ocpaws cost line item daily summary	33	view_ocpawscostlineitemdailysummary
+133	Can add cost usage report status	34	add_costusagereportstatus
+134	Can change cost usage report status	34	change_costusagereportstatus
+135	Can delete cost usage report status	34	delete_costusagereportstatus
+136	Can view cost usage report status	34	view_costusagereportstatus
+137	Can add region mapping	35	add_regionmapping
+138	Can change region mapping	35	change_regionmapping
+139	Can delete region mapping	35	delete_regionmapping
+140	Can view region mapping	35	view_regionmapping
+141	Can add report column map	36	add_reportcolumnmap
+142	Can change report column map	36	change_reportcolumnmap
+143	Can delete report column map	36	delete_reportcolumnmap
+144	Can view report column map	36	view_reportcolumnmap
+145	Can add si unit scale	37	add_siunitscale
+146	Can change si unit scale	37	change_siunitscale
+147	Can delete si unit scale	37	delete_siunitscale
+148	Can view si unit scale	37	view_siunitscale
+149	Can add cost usage report manifest	38	add_costusagereportmanifest
+150	Can change cost usage report manifest	38	change_costusagereportmanifest
+151	Can delete cost usage report manifest	38	delete_costusagereportmanifest
+152	Can view cost usage report manifest	38	view_costusagereportmanifest
+153	Can add rate	39	add_rate
+154	Can change rate	39	change_rate
+155	Can delete rate	39	delete_rate
+156	Can view rate	39	view_rate
 \.
 
 
 --
--- Data for Name: auth_user; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: auth_user; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.auth_user (id, password, last_login, is_superuser, username, first_name, last_name, email, is_staff, is_active, date_joined) FROM stdin;
@@ -2369,7 +2490,7 @@ COPY public.auth_user (id, password, last_login, is_superuser, username, first_n
 
 
 --
--- Data for Name: auth_user_groups; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: auth_user_groups; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.auth_user_groups (id, user_id, group_id) FROM stdin;
@@ -2377,7 +2498,7 @@ COPY public.auth_user_groups (id, user_id, group_id) FROM stdin;
 
 
 --
--- Data for Name: auth_user_user_permissions; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: auth_user_user_permissions; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.auth_user_user_permissions (id, user_id, permission_id) FROM stdin;
@@ -2385,7 +2506,7 @@ COPY public.auth_user_user_permissions (id, user_id, permission_id) FROM stdin;
 
 
 --
--- Data for Name: django_admin_log; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: django_admin_log; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.django_admin_log (id, action_time, object_id, object_repr, action_flag, change_message, content_type_id, user_id) FROM stdin;
@@ -2393,7 +2514,7 @@ COPY public.django_admin_log (id, action_time, object_id, object_repr, action_fl
 
 
 --
--- Data for Name: django_content_type; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: django_content_type; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.django_content_type (id, app_label, model) FROM stdin;
@@ -2428,80 +2549,84 @@ COPY public.django_content_type (id, app_label, model) FROM stdin;
 29	reporting	ocpusagelineitemdailysummary
 30	reporting	ocpusagepodlabelsummary
 31	reporting	awstagssummary
-32	reporting_common	costusagereportstatus
-33	reporting_common	regionmapping
-34	reporting_common	reportcolumnmap
-35	reporting_common	siunitscale
-36	reporting_common	costusagereportmanifest
-37	rates	rate
+32	reporting	ocpawscostlineitemdaily
+33	reporting	ocpawscostlineitemdailysummary
+34	reporting_common	costusagereportstatus
+35	reporting_common	regionmapping
+36	reporting_common	reportcolumnmap
+37	reporting_common	siunitscale
+38	reporting_common	costusagereportmanifest
+39	rates	rate
 \.
 
 
 --
--- Data for Name: django_migrations; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: django_migrations; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.django_migrations (id, app, name, applied) FROM stdin;
-1	contenttypes	0001_initial	2019-01-30 18:00:44.350105+00
-2	auth	0001_initial	2019-01-30 18:00:44.450055+00
-3	admin	0001_initial	2019-01-30 18:00:44.483246+00
-4	admin	0002_logentry_remove_auto_add	2019-01-30 18:00:44.498949+00
-5	admin	0003_logentry_add_action_flag_choices	2019-01-30 18:00:44.515287+00
-6	api	0001_initial	2019-01-30 18:00:44.71005+00
-7	api	0002_auto_20180926_1905	2019-01-30 18:00:44.721646+00
-8	api	0003_auto_20181008_1819	2019-01-30 18:00:44.771281+00
-9	api	0004_auto_20181012_1507	2019-01-30 18:00:44.788612+00
-10	api	0005_auto_20181109_2121	2019-01-30 18:00:44.81201+00
-11	api	0006_delete_rate	2019-01-30 18:00:44.819947+00
-12	api	0007_auto_20181213_1940	2019-01-30 18:00:44.864718+00
-13	contenttypes	0002_remove_content_type_name	2019-01-30 18:00:44.898806+00
-14	auth	0002_alter_permission_name_max_length	2019-01-30 18:00:44.90812+00
-15	auth	0003_alter_user_email_max_length	2019-01-30 18:00:44.927079+00
-16	auth	0004_alter_user_username_opts	2019-01-30 18:00:44.939839+00
-17	auth	0005_alter_user_last_login_null	2019-01-30 18:00:44.958564+00
-18	auth	0006_require_contenttypes_0002	2019-01-30 18:00:44.9611+00
-19	auth	0007_alter_validators_add_error_messages	2019-01-30 18:00:44.973243+00
-20	auth	0008_alter_user_username_max_length	2019-01-30 18:00:44.991757+00
-21	auth	0009_alter_user_last_name_max_length	2019-01-30 18:00:45.007157+00
-22	rates	0001_initial	2019-01-30 18:00:45.017953+00
-23	rates	0002_auto_20181205_1810	2019-01-30 18:00:45.02364+00
-24	reporting	0001_initial	2019-01-30 18:00:45.208559+00
-25	reporting	0002_auto_20180926_1818	2019-01-30 18:00:45.286349+00
-26	reporting	0003_auto_20180928_1840	2019-01-30 18:00:45.361965+00
-27	reporting	0004_auto_20181003_1633	2019-01-30 18:00:45.41396+00
-28	reporting	0005_auto_20181003_1416	2019-01-30 18:00:45.441528+00
-29	reporting	0006_awscostentrylineitemaggregates_account_alias	2019-01-30 18:00:45.453027+00
-30	reporting	0007_awscostentrybill_provider_id	2019-01-30 18:00:45.467179+00
-31	reporting	0008_auto_20181012_1724	2019-01-30 18:00:45.481795+00
-32	reporting	0009_auto_20181016_1940	2019-01-30 18:00:45.525649+00
-33	reporting	0010_auto_20181017_1659	2019-01-30 18:00:45.579419+00
-34	reporting	0011_auto_20181018_1811	2019-01-30 18:00:45.633634+00
-35	reporting	0012_auto_20181106_1502	2019-01-30 18:00:45.646136+00
-36	reporting	0013_auto_20181107_1956	2019-01-30 18:00:45.737669+00
-37	reporting	0014_auto_20181108_0207	2019-01-30 18:00:45.750974+00
-38	reporting	0015_auto_20181109_1618	2019-01-30 18:00:45.759338+00
-39	reporting	0016_delete_rate	2019-01-30 18:00:45.765648+00
-40	reporting	0017_auto_20181121_1444	2019-01-30 18:00:45.806452+00
-41	reporting	0018_auto_20181129_0217	2019-01-30 18:00:45.941311+00
-42	reporting	0019_auto_20181206_2138	2019-01-30 18:00:45.9644+00
-43	reporting	0020_auto_20181211_1557	2019-01-30 18:00:45.989709+00
-44	reporting	0021_auto_20181212_1816	2019-01-30 18:00:46.021743+00
-45	reporting	0022_auto_20181221_1617	2019-01-30 18:00:46.035815+00
-46	reporting	0023_awscostentrylineitemdailysummary_tags	2019-01-30 18:00:46.047461+00
-47	reporting	0024_ocpusagepodlabelsummary	2019-01-30 18:00:46.053701+00
-48	reporting	0025_auto_20190128_1825	2019-01-30 18:00:46.080588+00
-49	reporting	0026_auto_20190130_1746	2019-01-30 18:00:46.10406+00
-50	reporting_common	0001_initial	2019-01-30 18:00:46.171204+00
-51	reporting_common	0002_auto_20180926_1905	2019-01-30 18:00:46.296435+00
-52	reporting_common	0003_auto_20180928_1732	2019-01-30 18:00:46.367072+00
-53	reporting_common	0004_auto_20181003_1859	2019-01-30 18:00:46.441244+00
-54	reporting_common	0005_auto_20181127_2046	2019-01-30 18:00:46.513322+00
-55	sessions	0001_initial	2019-01-30 18:00:46.533811+00
+1	contenttypes	0001_initial	2019-02-05 20:54:58.370537+00
+2	auth	0001_initial	2019-02-05 20:54:58.473743+00
+3	admin	0001_initial	2019-02-05 20:54:58.506988+00
+4	admin	0002_logentry_remove_auto_add	2019-02-05 20:54:58.518284+00
+5	admin	0003_logentry_add_action_flag_choices	2019-02-05 20:54:58.530609+00
+6	api	0001_initial	2019-02-05 20:54:58.706988+00
+7	api	0002_auto_20180926_1905	2019-02-05 20:54:58.717334+00
+8	api	0003_auto_20181008_1819	2019-02-05 20:54:58.763927+00
+9	api	0004_auto_20181012_1507	2019-02-05 20:54:58.779528+00
+10	api	0005_auto_20181109_2121	2019-02-05 20:54:58.801552+00
+11	api	0006_delete_rate	2019-02-05 20:54:58.811955+00
+12	api	0007_auto_20181213_1940	2019-02-05 20:54:58.857681+00
+13	contenttypes	0002_remove_content_type_name	2019-02-05 20:54:58.885187+00
+14	auth	0002_alter_permission_name_max_length	2019-02-05 20:54:58.894579+00
+15	auth	0003_alter_user_email_max_length	2019-02-05 20:54:58.908367+00
+16	auth	0004_alter_user_username_opts	2019-02-05 20:54:58.921097+00
+17	auth	0005_alter_user_last_login_null	2019-02-05 20:54:58.934823+00
+18	auth	0006_require_contenttypes_0002	2019-02-05 20:54:58.938314+00
+19	auth	0007_alter_validators_add_error_messages	2019-02-05 20:54:58.949119+00
+20	auth	0008_alter_user_username_max_length	2019-02-05 20:54:58.966528+00
+21	auth	0009_alter_user_last_name_max_length	2019-02-05 20:54:58.979133+00
+22	rates	0001_initial	2019-02-05 20:54:58.98869+00
+23	rates	0002_auto_20181205_1810	2019-02-05 20:54:58.995169+00
+24	reporting	0001_initial	2019-02-05 20:54:59.133949+00
+25	reporting	0002_auto_20180926_1818	2019-02-05 20:54:59.193609+00
+26	reporting	0003_auto_20180928_1840	2019-02-05 20:54:59.248489+00
+27	reporting	0004_auto_20181003_1633	2019-02-05 20:54:59.289623+00
+28	reporting	0005_auto_20181003_1416	2019-02-05 20:54:59.312951+00
+29	reporting	0006_awscostentrylineitemaggregates_account_alias	2019-02-05 20:54:59.322915+00
+30	reporting	0007_awscostentrybill_provider_id	2019-02-05 20:54:59.334306+00
+31	reporting	0008_auto_20181012_1724	2019-02-05 20:54:59.346383+00
+32	reporting	0009_auto_20181016_1940	2019-02-05 20:54:59.412692+00
+33	reporting	0010_auto_20181017_1659	2019-02-05 20:54:59.454933+00
+34	reporting	0011_auto_20181018_1811	2019-02-05 20:54:59.496625+00
+35	reporting	0012_auto_20181106_1502	2019-02-05 20:54:59.509456+00
+36	reporting	0013_auto_20181107_1956	2019-02-05 20:54:59.57827+00
+37	reporting	0014_auto_20181108_0207	2019-02-05 20:54:59.590794+00
+38	reporting	0015_auto_20181109_1618	2019-02-05 20:54:59.598918+00
+39	reporting	0016_delete_rate	2019-02-05 20:54:59.605575+00
+40	reporting	0017_auto_20181121_1444	2019-02-05 20:54:59.637271+00
+41	reporting	0018_auto_20181129_0217	2019-02-05 20:54:59.7431+00
+42	reporting	0019_auto_20181206_2138	2019-02-05 20:54:59.761596+00
+43	reporting	0020_auto_20181211_1557	2019-02-05 20:54:59.781148+00
+44	reporting	0021_auto_20181212_1816	2019-02-05 20:54:59.809366+00
+45	reporting	0022_auto_20181221_1617	2019-02-05 20:54:59.823685+00
+46	reporting	0023_awscostentrylineitemdailysummary_tags	2019-02-05 20:54:59.83382+00
+47	reporting	0024_ocpusagepodlabelsummary	2019-02-05 20:54:59.84103+00
+48	reporting	0025_auto_20190128_1825	2019-02-05 20:54:59.864363+00
+49	reporting	0026_auto_20190130_1746	2019-02-05 20:54:59.882301+00
+50	reporting	0027_auto_20190205_1659	2019-02-05 20:54:59.889474+00
+51	reporting	0028_auto_20190205_2022	2019-02-05 20:54:59.935009+00
+52	reporting_common	0001_initial	2019-02-05 20:55:00.004386+00
+53	reporting_common	0002_auto_20180926_1905	2019-02-05 20:55:00.104809+00
+54	reporting_common	0003_auto_20180928_1732	2019-02-05 20:55:00.173311+00
+55	reporting_common	0004_auto_20181003_1859	2019-02-05 20:55:00.242919+00
+56	reporting_common	0005_auto_20181127_2046	2019-02-05 20:55:00.319149+00
+57	sessions	0001_initial	2019-02-05 20:55:00.341073+00
 \.
 
 
 --
--- Data for Name: django_session; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: django_session; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.django_session (session_key, session_data, expire_date) FROM stdin;
@@ -2509,7 +2634,7 @@ COPY public.django_session (session_key, session_data, expire_date) FROM stdin;
 
 
 --
--- Data for Name: region_mapping; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: region_mapping; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.region_mapping (id, region, region_name) FROM stdin;
@@ -2517,7 +2642,7 @@ COPY public.region_mapping (id, region, region_name) FROM stdin;
 
 
 --
--- Data for Name: reporting_common_costusagereportmanifest; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: reporting_common_costusagereportmanifest; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.reporting_common_costusagereportmanifest (id, assembly_id, manifest_creation_datetime, manifest_updated_datetime, billing_period_start_datetime, num_processed_files, num_total_files, provider_id) FROM stdin;
@@ -2525,7 +2650,7 @@ COPY public.reporting_common_costusagereportmanifest (id, assembly_id, manifest_
 
 
 --
--- Data for Name: reporting_common_costusagereportstatus; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: reporting_common_costusagereportstatus; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.reporting_common_costusagereportstatus (id, report_name, last_completed_datetime, last_started_datetime, etag, manifest_id) FROM stdin;
@@ -2533,7 +2658,7 @@ COPY public.reporting_common_costusagereportstatus (id, report_name, last_comple
 
 
 --
--- Data for Name: reporting_common_reportcolumnmap; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: reporting_common_reportcolumnmap; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.reporting_common_reportcolumnmap (id, provider_type, provider_column_name, database_table, database_column) FROM stdin;
@@ -2608,7 +2733,7 @@ COPY public.reporting_common_reportcolumnmap (id, provider_type, provider_column
 
 
 --
--- Data for Name: si_unit_scale; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Data for Name: si_unit_scale; Type: TABLE DATA; Schema: public; Owner: kokuadmin
 --
 
 COPY public.si_unit_scale (id, prefix, prefix_symbol, multiplying_factor) FROM stdin;
@@ -2616,280 +2741,287 @@ COPY public.si_unit_scale (id, prefix, prefix_symbol, multiplying_factor) FROM s
 
 
 --
--- Name: django_migrations_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: django_migrations_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
-SELECT pg_catalog.setval('acct10001.django_migrations_id_seq', 55, true);
+SELECT pg_catalog.setval('acct10001.django_migrations_id_seq', 57, true);
 
 
 --
--- Name: rates_rate_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: rates_rate_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.rates_rate_id_seq', 1, false);
 
 
 --
--- Name: reporting_awsaccountalias_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awsaccountalias_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awsaccountalias_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentry_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentry_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentry_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentrybill_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrybill_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentrybill_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentrylineitem_aggregates_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_aggregates_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentrylineitem_aggregates_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentrylineitem_daily_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentrylineitem_daily_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentrylineitem_daily_summary_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_summary_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentrylineitem_daily_summary_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentrylineitem_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentrylineitem_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentrypricing_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrypricing_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentrypricing_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentryproduct_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryproduct_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentryproduct_id_seq', 1, false);
 
 
 --
--- Name: reporting_awscostentryreservation_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryreservation_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_awscostentryreservation_id_seq', 1, false);
 
 
 --
--- Name: reporting_ocpusagelineitem_aggregates_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpawscostlineitem_daily_summary_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
+--
+
+SELECT pg_catalog.setval('acct10001.reporting_ocpawscostlineitem_daily_summary_id_seq', 1, false);
+
+
+--
+-- Name: reporting_ocpusagelineitem_aggregates_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_ocpusagelineitem_aggregates_id_seq', 1, false);
 
 
 --
--- Name: reporting_ocpusagelineitem_daily_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_ocpusagelineitem_daily_id_seq', 1, false);
 
 
 --
--- Name: reporting_ocpusagelineitem_daily_summary_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily_summary_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_ocpusagelineitem_daily_summary_id_seq', 1, false);
 
 
 --
--- Name: reporting_ocpusagelineitem_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_ocpusagelineitem_id_seq', 1, false);
 
 
 --
--- Name: reporting_ocpusagereport_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_ocpusagereport_id_seq', 1, false);
 
 
 --
--- Name: reporting_ocpusagereportperiod_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereportperiod_id_seq; Type: SEQUENCE SET; Schema: acct10001; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('acct10001.reporting_ocpusagereportperiod_id_seq', 1, false);
 
 
 --
--- Name: api_customer_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: api_customer_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.api_customer_id_seq', 1, true);
 
 
 --
--- Name: api_provider_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: api_provider_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.api_provider_id_seq', 2, true);
 
 
 --
--- Name: api_providerauthentication_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: api_providerauthentication_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.api_providerauthentication_id_seq', 2, true);
 
 
 --
--- Name: api_providerbillingsource_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: api_providerbillingsource_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.api_providerbillingsource_id_seq', 1, true);
 
 
 --
--- Name: api_tenant_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: api_tenant_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.api_tenant_id_seq', 1, true);
 
 
 --
--- Name: api_user_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: api_user_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.api_user_id_seq', 1, true);
 
 
 --
--- Name: api_userpreference_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: api_userpreference_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.api_userpreference_id_seq', 3, true);
 
 
 --
--- Name: auth_group_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: auth_group_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.auth_group_id_seq', 1, false);
 
 
 --
--- Name: auth_group_permissions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: auth_group_permissions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.auth_group_permissions_id_seq', 1, false);
 
 
 --
--- Name: auth_permission_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: auth_permission_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
-SELECT pg_catalog.setval('public.auth_permission_id_seq', 148, true);
+SELECT pg_catalog.setval('public.auth_permission_id_seq', 156, true);
 
 
 --
--- Name: auth_user_groups_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: auth_user_groups_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.auth_user_groups_id_seq', 1, false);
 
 
 --
--- Name: auth_user_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: auth_user_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.auth_user_id_seq', 1, false);
 
 
 --
--- Name: auth_user_user_permissions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.auth_user_user_permissions_id_seq', 1, false);
 
 
 --
--- Name: django_admin_log_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: django_admin_log_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.django_admin_log_id_seq', 1, false);
 
 
 --
--- Name: django_content_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: django_content_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
-SELECT pg_catalog.setval('public.django_content_type_id_seq', 37, true);
-
-
---
--- Name: django_migrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
---
-
-SELECT pg_catalog.setval('public.django_migrations_id_seq', 55, true);
+SELECT pg_catalog.setval('public.django_content_type_id_seq', 39, true);
 
 
 --
--- Name: region_mapping_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: django_migrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
+--
+
+SELECT pg_catalog.setval('public.django_migrations_id_seq', 57, true);
+
+
+--
+-- Name: region_mapping_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.region_mapping_id_seq', 1, false);
 
 
 --
--- Name: reporting_common_costusagereportmanifest_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.reporting_common_costusagereportmanifest_id_seq', 1, false);
 
 
 --
--- Name: reporting_common_costusagereportstatus_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.reporting_common_costusagereportstatus_id_seq', 1, false);
 
 
 --
--- Name: reporting_common_reportcolumnmap_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: reporting_common_reportcolumnmap_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.reporting_common_reportcolumnmap_id_seq', 87, true);
 
 
 --
--- Name: si_unit_scale_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+-- Name: si_unit_scale_id_seq; Type: SEQUENCE SET; Schema: public; Owner: kokuadmin
 --
 
 SELECT pg_catalog.setval('public.si_unit_scale_id_seq', 1, false);
 
 
 --
--- Name: django_migrations django_migrations_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: django_migrations django_migrations_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.django_migrations
@@ -2897,7 +3029,7 @@ ALTER TABLE ONLY acct10001.django_migrations
 
 
 --
--- Name: rates_rate rates_rate_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: rates_rate rates_rate_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.rates_rate
@@ -2905,7 +3037,7 @@ ALTER TABLE ONLY acct10001.rates_rate
 
 
 --
--- Name: rates_rate rates_rate_provider_uuid_metric_1f411ad3_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: rates_rate rates_rate_provider_uuid_metric_1f411ad3_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.rates_rate
@@ -2913,7 +3045,7 @@ ALTER TABLE ONLY acct10001.rates_rate
 
 
 --
--- Name: rates_rate rates_rate_uuid_key; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: rates_rate rates_rate_uuid_key; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.rates_rate
@@ -2921,7 +3053,7 @@ ALTER TABLE ONLY acct10001.rates_rate
 
 
 --
--- Name: reporting_awsaccountalias reporting_awsaccountalias_account_id_key; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awsaccountalias reporting_awsaccountalias_account_id_key; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awsaccountalias
@@ -2929,7 +3061,7 @@ ALTER TABLE ONLY acct10001.reporting_awsaccountalias
 
 
 --
--- Name: reporting_awsaccountalias reporting_awsaccountalias_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awsaccountalias reporting_awsaccountalias_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awsaccountalias
@@ -2937,7 +3069,7 @@ ALTER TABLE ONLY acct10001.reporting_awsaccountalias
 
 
 --
--- Name: reporting_awscostentry reporting_awscostentry_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentry reporting_awscostentry_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentry
@@ -2945,7 +3077,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentry
 
 
 --
--- Name: reporting_awscostentrybill reporting_awscostentrybi_bill_type_payer_account__2d62ede9_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrybill reporting_awscostentrybi_bill_type_payer_account__2d62ede9_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrybill
@@ -2953,7 +3085,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrybill
 
 
 --
--- Name: reporting_awscostentrybill reporting_awscostentrybill_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrybill reporting_awscostentrybill_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrybill
@@ -2961,7 +3093,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrybill
 
 
 --
--- Name: reporting_awscostentrylineitem_aggregates reporting_awscostentrylineitem_aggregates_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_aggregates reporting_awscostentrylineitem_aggregates_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_aggregates
@@ -2969,7 +3101,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_aggregates
 
 
 --
--- Name: reporting_awscostentrylineitem_daily reporting_awscostentrylineitem_daily_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily reporting_awscostentrylineitem_daily_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily
@@ -2977,7 +3109,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily
 
 
 --
--- Name: reporting_awscostentrylineitem_daily_summary reporting_awscostentrylineitem_daily_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_summary reporting_awscostentrylineitem_daily_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily_summary
@@ -2985,7 +3117,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily_summary
 
 
 --
--- Name: reporting_awscostentrylineitem reporting_awscostentrylineitem_hash_cost_entry_id_f3893306_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem reporting_awscostentrylineitem_hash_cost_entry_id_f3893306_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
@@ -2993,7 +3125,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
 
 
 --
--- Name: reporting_awscostentrylineitem reporting_awscostentrylineitem_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem reporting_awscostentrylineitem_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
@@ -3001,7 +3133,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
 
 
 --
--- Name: reporting_awscostentryproduct reporting_awscostentrypr_sku_product_name_region_fea902ae_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryproduct reporting_awscostentrypr_sku_product_name_region_fea902ae_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentryproduct
@@ -3009,7 +3141,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentryproduct
 
 
 --
--- Name: reporting_awscostentrypricing reporting_awscostentrypricing_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrypricing reporting_awscostentrypricing_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrypricing
@@ -3017,7 +3149,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrypricing
 
 
 --
--- Name: reporting_awscostentrypricing reporting_awscostentrypricing_term_unit_c3978af3_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrypricing reporting_awscostentrypricing_term_unit_c3978af3_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrypricing
@@ -3025,7 +3157,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrypricing
 
 
 --
--- Name: reporting_awscostentryproduct reporting_awscostentryproduct_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryproduct reporting_awscostentryproduct_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentryproduct
@@ -3033,7 +3165,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentryproduct
 
 
 --
--- Name: reporting_awscostentryreservation reporting_awscostentryreservation_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryreservation reporting_awscostentryreservation_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentryreservation
@@ -3041,7 +3173,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentryreservation
 
 
 --
--- Name: reporting_awscostentryreservation reporting_awscostentryreservation_reservation_arn_key; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryreservation reporting_awscostentryreservation_reservation_arn_key; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentryreservation
@@ -3049,7 +3181,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentryreservation
 
 
 --
--- Name: reporting_awstags_summary reporting_awstags_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awstags_summary reporting_awstags_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awstags_summary
@@ -3057,7 +3189,15 @@ ALTER TABLE ONLY acct10001.reporting_awstags_summary
 
 
 --
--- Name: reporting_ocpusagelineitem reporting_ocpusagelineit_report_id_namespace_pod__dfc2c342_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpawscostlineitem_daily_summary reporting_ocpawscostlineitem_daily_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
+--
+
+ALTER TABLE ONLY acct10001.reporting_ocpawscostlineitem_daily_summary
+    ADD CONSTRAINT reporting_ocpawscostlineitem_daily_summary_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reporting_ocpusagelineitem reporting_ocpusagelineit_report_id_namespace_pod__dfc2c342_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem
@@ -3065,7 +3205,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem
 
 
 --
--- Name: reporting_ocpusagelineitem_aggregates reporting_ocpusagelineitem_aggregates_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_aggregates reporting_ocpusagelineitem_aggregates_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_aggregates
@@ -3073,7 +3213,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_aggregates
 
 
 --
--- Name: reporting_ocpusagelineitem_daily reporting_ocpusagelineitem_daily_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily reporting_ocpusagelineitem_daily_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_daily
@@ -3081,7 +3221,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_daily
 
 
 --
--- Name: reporting_ocpusagelineitem_daily_summary reporting_ocpusagelineitem_daily_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_daily_summary reporting_ocpusagelineitem_daily_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_daily_summary
@@ -3089,7 +3229,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem_daily_summary
 
 
 --
--- Name: reporting_ocpusagelineitem reporting_ocpusagelineitem_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem reporting_ocpusagelineitem_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem
@@ -3097,7 +3237,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem
 
 
 --
--- Name: reporting_ocpusagepodlabel_summary reporting_ocpusagepodlabel_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagepodlabel_summary reporting_ocpusagepodlabel_summary_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagepodlabel_summary
@@ -3105,7 +3245,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagepodlabel_summary
 
 
 --
--- Name: reporting_ocpusagereportperiod reporting_ocpusagereport_cluster_id_report_period_94b94003_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereportperiod reporting_ocpusagereport_cluster_id_report_period_94b94003_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagereportperiod
@@ -3113,7 +3253,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagereportperiod
 
 
 --
--- Name: reporting_ocpusagereport reporting_ocpusagereport_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport reporting_ocpusagereport_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagereport
@@ -3121,7 +3261,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagereport
 
 
 --
--- Name: reporting_ocpusagereport reporting_ocpusagereport_report_period_id_interva_066551f3_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport reporting_ocpusagereport_report_period_id_interva_066551f3_uniq; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagereport
@@ -3129,7 +3269,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagereport
 
 
 --
--- Name: reporting_ocpusagereportperiod reporting_ocpusagereportperiod_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereportperiod reporting_ocpusagereportperiod_pkey; Type: CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagereportperiod
@@ -3137,7 +3277,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagereportperiod
 
 
 --
--- Name: api_customer api_customer_account_id_206bec02_uniq; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_customer api_customer_account_id_206bec02_uniq; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_customer
@@ -3145,7 +3285,7 @@ ALTER TABLE ONLY public.api_customer
 
 
 --
--- Name: api_customer api_customer_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_customer api_customer_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_customer
@@ -3153,7 +3293,7 @@ ALTER TABLE ONLY public.api_customer
 
 
 --
--- Name: api_customer api_customer_schema_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_customer api_customer_schema_name_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_customer
@@ -3161,7 +3301,7 @@ ALTER TABLE ONLY public.api_customer
 
 
 --
--- Name: api_customer api_customer_uuid_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_customer api_customer_uuid_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_customer
@@ -3169,7 +3309,7 @@ ALTER TABLE ONLY public.api_customer
 
 
 --
--- Name: api_provider api_provider_authentication_id_billing_source_id_8f2af497_uniq; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_provider api_provider_authentication_id_billing_source_id_8f2af497_uniq; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_provider
@@ -3177,7 +3317,7 @@ ALTER TABLE ONLY public.api_provider
 
 
 --
--- Name: api_provider api_provider_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_provider api_provider_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_provider
@@ -3185,7 +3325,7 @@ ALTER TABLE ONLY public.api_provider
 
 
 --
--- Name: api_provider api_provider_uuid_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_provider api_provider_uuid_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_provider
@@ -3193,7 +3333,7 @@ ALTER TABLE ONLY public.api_provider
 
 
 --
--- Name: api_providerauthentication api_providerauthentication_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_providerauthentication api_providerauthentication_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_providerauthentication
@@ -3201,7 +3341,7 @@ ALTER TABLE ONLY public.api_providerauthentication
 
 
 --
--- Name: api_providerauthentication api_providerauthentication_provider_resource_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_providerauthentication api_providerauthentication_provider_resource_name_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_providerauthentication
@@ -3209,7 +3349,7 @@ ALTER TABLE ONLY public.api_providerauthentication
 
 
 --
--- Name: api_providerauthentication api_providerauthentication_uuid_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_providerauthentication api_providerauthentication_uuid_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_providerauthentication
@@ -3217,7 +3357,7 @@ ALTER TABLE ONLY public.api_providerauthentication
 
 
 --
--- Name: api_providerbillingsource api_providerbillingsource_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_providerbillingsource api_providerbillingsource_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_providerbillingsource
@@ -3225,7 +3365,7 @@ ALTER TABLE ONLY public.api_providerbillingsource
 
 
 --
--- Name: api_providerbillingsource api_providerbillingsource_uuid_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_providerbillingsource api_providerbillingsource_uuid_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_providerbillingsource
@@ -3233,7 +3373,7 @@ ALTER TABLE ONLY public.api_providerbillingsource
 
 
 --
--- Name: api_tenant api_tenant_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_tenant api_tenant_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_tenant
@@ -3241,7 +3381,7 @@ ALTER TABLE ONLY public.api_tenant
 
 
 --
--- Name: api_tenant api_tenant_schema_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_tenant api_tenant_schema_name_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_tenant
@@ -3249,7 +3389,7 @@ ALTER TABLE ONLY public.api_tenant
 
 
 --
--- Name: api_user api_user_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_user api_user_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_user
@@ -3257,7 +3397,7 @@ ALTER TABLE ONLY public.api_user
 
 
 --
--- Name: api_user api_user_username_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_user api_user_username_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_user
@@ -3265,7 +3405,7 @@ ALTER TABLE ONLY public.api_user
 
 
 --
--- Name: api_user api_user_uuid_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_user api_user_uuid_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_user
@@ -3273,7 +3413,7 @@ ALTER TABLE ONLY public.api_user
 
 
 --
--- Name: api_userpreference api_userpreference_name_user_id_9f2a465b_uniq; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_userpreference api_userpreference_name_user_id_9f2a465b_uniq; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_userpreference
@@ -3281,7 +3421,7 @@ ALTER TABLE ONLY public.api_userpreference
 
 
 --
--- Name: api_userpreference api_userpreference_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_userpreference api_userpreference_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_userpreference
@@ -3289,7 +3429,7 @@ ALTER TABLE ONLY public.api_userpreference
 
 
 --
--- Name: api_userpreference api_userpreference_uuid_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_userpreference api_userpreference_uuid_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_userpreference
@@ -3297,7 +3437,7 @@ ALTER TABLE ONLY public.api_userpreference
 
 
 --
--- Name: auth_group auth_group_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_group auth_group_name_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_group
@@ -3305,7 +3445,7 @@ ALTER TABLE ONLY public.auth_group
 
 
 --
--- Name: auth_group_permissions auth_group_permissions_group_id_permission_id_0cd325b0_uniq; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_group_permissions auth_group_permissions_group_id_permission_id_0cd325b0_uniq; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_group_permissions
@@ -3313,7 +3453,7 @@ ALTER TABLE ONLY public.auth_group_permissions
 
 
 --
--- Name: auth_group_permissions auth_group_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_group_permissions auth_group_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_group_permissions
@@ -3321,7 +3461,7 @@ ALTER TABLE ONLY public.auth_group_permissions
 
 
 --
--- Name: auth_group auth_group_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_group auth_group_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_group
@@ -3329,7 +3469,7 @@ ALTER TABLE ONLY public.auth_group
 
 
 --
--- Name: auth_permission auth_permission_content_type_id_codename_01ab375a_uniq; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_permission auth_permission_content_type_id_codename_01ab375a_uniq; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_permission
@@ -3337,7 +3477,7 @@ ALTER TABLE ONLY public.auth_permission
 
 
 --
--- Name: auth_permission auth_permission_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_permission auth_permission_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_permission
@@ -3345,7 +3485,7 @@ ALTER TABLE ONLY public.auth_permission
 
 
 --
--- Name: auth_user_groups auth_user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user_groups auth_user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_groups
@@ -3353,7 +3493,7 @@ ALTER TABLE ONLY public.auth_user_groups
 
 
 --
--- Name: auth_user_groups auth_user_groups_user_id_group_id_94350c0c_uniq; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user_groups auth_user_groups_user_id_group_id_94350c0c_uniq; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_groups
@@ -3361,7 +3501,7 @@ ALTER TABLE ONLY public.auth_user_groups
 
 
 --
--- Name: auth_user auth_user_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user auth_user_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user
@@ -3369,7 +3509,7 @@ ALTER TABLE ONLY public.auth_user
 
 
 --
--- Name: auth_user_user_permissions auth_user_user_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions auth_user_user_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_user_permissions
@@ -3377,7 +3517,7 @@ ALTER TABLE ONLY public.auth_user_user_permissions
 
 
 --
--- Name: auth_user_user_permissions auth_user_user_permissions_user_id_permission_id_14a6b632_uniq; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions auth_user_user_permissions_user_id_permission_id_14a6b632_uniq; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_user_permissions
@@ -3385,7 +3525,7 @@ ALTER TABLE ONLY public.auth_user_user_permissions
 
 
 --
--- Name: auth_user auth_user_username_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user auth_user_username_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user
@@ -3393,7 +3533,7 @@ ALTER TABLE ONLY public.auth_user
 
 
 --
--- Name: django_admin_log django_admin_log_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: django_admin_log django_admin_log_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_admin_log
@@ -3401,7 +3541,7 @@ ALTER TABLE ONLY public.django_admin_log
 
 
 --
--- Name: django_content_type django_content_type_app_label_model_76bd3d3b_uniq; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: django_content_type django_content_type_app_label_model_76bd3d3b_uniq; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_content_type
@@ -3409,7 +3549,7 @@ ALTER TABLE ONLY public.django_content_type
 
 
 --
--- Name: django_content_type django_content_type_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: django_content_type django_content_type_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_content_type
@@ -3417,7 +3557,7 @@ ALTER TABLE ONLY public.django_content_type
 
 
 --
--- Name: django_migrations django_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: django_migrations django_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_migrations
@@ -3425,7 +3565,7 @@ ALTER TABLE ONLY public.django_migrations
 
 
 --
--- Name: django_session django_session_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: django_session django_session_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_session
@@ -3433,7 +3573,7 @@ ALTER TABLE ONLY public.django_session
 
 
 --
--- Name: region_mapping region_mapping_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: region_mapping region_mapping_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.region_mapping
@@ -3441,7 +3581,7 @@ ALTER TABLE ONLY public.region_mapping
 
 
 --
--- Name: region_mapping region_mapping_region_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: region_mapping region_mapping_region_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.region_mapping
@@ -3449,7 +3589,7 @@ ALTER TABLE ONLY public.region_mapping
 
 
 --
--- Name: region_mapping region_mapping_region_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: region_mapping region_mapping_region_name_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.region_mapping
@@ -3457,7 +3597,7 @@ ALTER TABLE ONLY public.region_mapping
 
 
 --
--- Name: reporting_common_costusagereportmanifest reporting_common_costusagereportmanifest_assembly_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest reporting_common_costusagereportmanifest_assembly_id_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_costusagereportmanifest
@@ -3465,7 +3605,7 @@ ALTER TABLE ONLY public.reporting_common_costusagereportmanifest
 
 
 --
--- Name: reporting_common_costusagereportmanifest reporting_common_costusagereportmanifest_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest reporting_common_costusagereportmanifest_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_costusagereportmanifest
@@ -3473,7 +3613,7 @@ ALTER TABLE ONLY public.reporting_common_costusagereportmanifest
 
 
 --
--- Name: reporting_common_costusagereportstatus reporting_common_costusagereportstatus_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus reporting_common_costusagereportstatus_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_costusagereportstatus
@@ -3481,7 +3621,7 @@ ALTER TABLE ONLY public.reporting_common_costusagereportstatus
 
 
 --
--- Name: reporting_common_costusagereportstatus reporting_common_costusagereportstatus_report_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus reporting_common_costusagereportstatus_report_name_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_costusagereportstatus
@@ -3489,7 +3629,7 @@ ALTER TABLE ONLY public.reporting_common_costusagereportstatus
 
 
 --
--- Name: reporting_common_reportcolumnmap reporting_common_reportcolumnmap_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: reporting_common_reportcolumnmap reporting_common_reportcolumnmap_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_reportcolumnmap
@@ -3497,7 +3637,7 @@ ALTER TABLE ONLY public.reporting_common_reportcolumnmap
 
 
 --
--- Name: reporting_common_reportcolumnmap reporting_common_reportcolumnmap_provider_column_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: reporting_common_reportcolumnmap reporting_common_reportcolumnmap_provider_column_name_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_reportcolumnmap
@@ -3505,7 +3645,7 @@ ALTER TABLE ONLY public.reporting_common_reportcolumnmap
 
 
 --
--- Name: si_unit_scale si_unit_scale_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: si_unit_scale si_unit_scale_pkey; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.si_unit_scale
@@ -3513,7 +3653,7 @@ ALTER TABLE ONLY public.si_unit_scale
 
 
 --
--- Name: si_unit_scale si_unit_scale_prefix_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: si_unit_scale si_unit_scale_prefix_key; Type: CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.si_unit_scale
@@ -3521,490 +3661,525 @@ ALTER TABLE ONLY public.si_unit_scale
 
 
 --
--- Name: interval_start_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: cost_pod_labels_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE INDEX cost_pod_labels_idx ON acct10001.reporting_ocpawscostlineitem_daily_summary USING gin (pod_labels);
+
+
+--
+-- Name: cost_summary_namespace_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE INDEX cost_summary_namespace_idx ON acct10001.reporting_ocpawscostlineitem_daily_summary USING btree (namespace);
+
+
+--
+-- Name: cost_summary_node_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE INDEX cost_summary_node_idx ON acct10001.reporting_ocpawscostlineitem_daily_summary USING btree (node);
+
+
+--
+-- Name: cost_summary_ocp_usage_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE INDEX cost_summary_ocp_usage_idx ON acct10001.reporting_ocpawscostlineitem_daily_summary USING btree (usage_start);
+
+
+--
+-- Name: interval_start_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX interval_start_idx ON acct10001.reporting_awscostentry USING btree (interval_start);
 
 
 --
--- Name: namespace_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: namespace_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX namespace_idx ON acct10001.reporting_ocpusagelineitem_daily USING btree (namespace);
 
 
 --
--- Name: node_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: node_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX node_idx ON acct10001.reporting_ocpusagelineitem_daily USING btree (node);
 
 
 --
--- Name: ocp_interval_start_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: ocp_interval_start_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX ocp_interval_start_idx ON acct10001.reporting_ocpusagereport USING btree (interval_start);
 
 
 --
--- Name: ocp_usage_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: ocp_usage_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX ocp_usage_idx ON acct10001.reporting_ocpusagelineitem_daily USING btree (usage_start);
 
 
 --
--- Name: pod_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: pod_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX pod_idx ON acct10001.reporting_ocpusagelineitem_daily USING btree (pod);
 
 
 --
--- Name: pod_labels_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: pod_labels_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX pod_labels_idx ON acct10001.reporting_ocpusagelineitem_daily_summary USING gin (pod_labels);
 
 
 --
--- Name: product_code_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: product_code_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX product_code_idx ON acct10001.reporting_awscostentrylineitem_daily USING btree (product_code);
 
 
 --
--- Name: region_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: region_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX region_idx ON acct10001.reporting_awscostentryproduct USING btree (region);
 
 
 --
--- Name: reporting_awsaccountalias_account_id_85724b8c_like; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awsaccountalias_account_id_85724b8c_like; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awsaccountalias_account_id_85724b8c_like ON acct10001.reporting_awsaccountalias USING btree (account_id varchar_pattern_ops);
 
 
 --
--- Name: reporting_awscostentry_bill_id_017f27a3; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentry_bill_id_017f27a3; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentry_bill_id_017f27a3 ON acct10001.reporting_awscostentry USING btree (bill_id);
 
 
 --
--- Name: reporting_awscostentryline_account_alias_id_684d6c01; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryline_account_alias_id_684d6c01; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentryline_account_alias_id_684d6c01 ON acct10001.reporting_awscostentrylineitem_daily_summary USING btree (account_alias_id);
 
 
 --
--- Name: reporting_awscostentryline_account_alias_id_f97d76e5; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryline_account_alias_id_f97d76e5; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentryline_account_alias_id_f97d76e5 ON acct10001.reporting_awscostentrylineitem_aggregates USING btree (account_alias_id);
 
 
 --
--- Name: reporting_awscostentryline_cost_entry_pricing_id_5a6a9b38; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryline_cost_entry_pricing_id_5a6a9b38; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentryline_cost_entry_pricing_id_5a6a9b38 ON acct10001.reporting_awscostentrylineitem_daily USING btree (cost_entry_pricing_id);
 
 
 --
--- Name: reporting_awscostentryline_cost_entry_product_id_4d8ef2fd; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryline_cost_entry_product_id_4d8ef2fd; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentryline_cost_entry_product_id_4d8ef2fd ON acct10001.reporting_awscostentrylineitem_daily USING btree (cost_entry_product_id);
 
 
 --
--- Name: reporting_awscostentryline_cost_entry_reservation_id_13b1cb08; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryline_cost_entry_reservation_id_13b1cb08; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentryline_cost_entry_reservation_id_13b1cb08 ON acct10001.reporting_awscostentrylineitem_daily USING btree (cost_entry_reservation_id);
 
 
 --
--- Name: reporting_awscostentryline_cost_entry_reservation_id_9332b371; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryline_cost_entry_reservation_id_9332b371; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentryline_cost_entry_reservation_id_9332b371 ON acct10001.reporting_awscostentrylineitem USING btree (cost_entry_reservation_id);
 
 
 --
--- Name: reporting_awscostentrylineitem_cost_entry_bill_id_5ae74e09; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_cost_entry_bill_id_5ae74e09; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentrylineitem_cost_entry_bill_id_5ae74e09 ON acct10001.reporting_awscostentrylineitem USING btree (cost_entry_bill_id);
 
 
 --
--- Name: reporting_awscostentrylineitem_cost_entry_id_4d1a7fc4; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_cost_entry_id_4d1a7fc4; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentrylineitem_cost_entry_id_4d1a7fc4 ON acct10001.reporting_awscostentrylineitem USING btree (cost_entry_id);
 
 
 --
--- Name: reporting_awscostentrylineitem_cost_entry_pricing_id_a654a7e3; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_cost_entry_pricing_id_a654a7e3; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentrylineitem_cost_entry_pricing_id_a654a7e3 ON acct10001.reporting_awscostentrylineitem USING btree (cost_entry_pricing_id);
 
 
 --
--- Name: reporting_awscostentrylineitem_cost_entry_product_id_29c80210; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_cost_entry_product_id_29c80210; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentrylineitem_cost_entry_product_id_29c80210 ON acct10001.reporting_awscostentrylineitem USING btree (cost_entry_product_id);
 
 
 --
--- Name: reporting_awscostentryreservation_reservation_arn_e387aa5b_like; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentryreservation_reservation_arn_e387aa5b_like; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awscostentryreservation_reservation_arn_e387aa5b_like ON acct10001.reporting_awscostentryreservation USING btree (reservation_arn text_pattern_ops);
 
 
 --
--- Name: reporting_awstags_summary_key_c99caa53_like; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_awstags_summary_key_c99caa53_like; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_awstags_summary_key_c99caa53_like ON acct10001.reporting_awstags_summary USING btree (key varchar_pattern_ops);
 
 
 --
--- Name: reporting_ocpusagelineitem_report_id_32a973b0; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpawscostlineit_account_alias_id_f19d2883; Type: INDEX; Schema: acct10001; Owner: kokuadmin
+--
+
+CREATE INDEX reporting_ocpawscostlineit_account_alias_id_f19d2883 ON acct10001.reporting_ocpawscostlineitem_daily_summary USING btree (account_alias_id);
+
+
+--
+-- Name: reporting_ocpusagelineitem_report_id_32a973b0; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_ocpusagelineitem_report_id_32a973b0 ON acct10001.reporting_ocpusagelineitem USING btree (report_id);
 
 
 --
--- Name: reporting_ocpusagelineitem_report_period_id_be7fa5ad; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem_report_period_id_be7fa5ad; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_ocpusagelineitem_report_period_id_be7fa5ad ON acct10001.reporting_ocpusagelineitem USING btree (report_period_id);
 
 
 --
--- Name: reporting_ocpusagepodlabel_summary_key_fa0b8105_like; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagepodlabel_summary_key_fa0b8105_like; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_ocpusagepodlabel_summary_key_fa0b8105_like ON acct10001.reporting_ocpusagepodlabel_summary USING btree (key varchar_pattern_ops);
 
 
 --
--- Name: reporting_ocpusagereport_report_period_id_477508c6; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport_report_period_id_477508c6; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_ocpusagereport_report_period_id_477508c6 ON acct10001.reporting_ocpusagereport USING btree (report_period_id);
 
 
 --
--- Name: summary_namespace_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: summary_namespace_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX summary_namespace_idx ON acct10001.reporting_ocpusagelineitem_daily_summary USING btree (namespace);
 
 
 --
--- Name: summary_node_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: summary_node_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX summary_node_idx ON acct10001.reporting_ocpusagelineitem_daily_summary USING btree (node);
 
 
 --
--- Name: summary_ocp_usage_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: summary_ocp_usage_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX summary_ocp_usage_idx ON acct10001.reporting_ocpusagelineitem_daily_summary USING btree (usage_start);
 
 
 --
--- Name: summary_pod_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: summary_pod_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX summary_pod_idx ON acct10001.reporting_ocpusagelineitem_daily_summary USING btree (pod);
 
 
 --
--- Name: summary_product_code_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: summary_product_code_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX summary_product_code_idx ON acct10001.reporting_awscostentrylineitem_daily_summary USING btree (product_code);
 
 
 --
--- Name: summary_usage_account_id_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: summary_usage_account_id_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX summary_usage_account_id_idx ON acct10001.reporting_awscostentrylineitem_daily_summary USING btree (usage_account_id);
 
 
 --
--- Name: summary_usage_start_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: summary_usage_start_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX summary_usage_start_idx ON acct10001.reporting_awscostentrylineitem_daily_summary USING btree (usage_start);
 
 
 --
--- Name: tags_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: tags_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX tags_idx ON acct10001.reporting_awscostentrylineitem_daily_summary USING gin (tags);
 
 
 --
--- Name: usage_account_id_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: usage_account_id_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX usage_account_id_idx ON acct10001.reporting_awscostentrylineitem_daily USING btree (usage_account_id);
 
 
 --
--- Name: usage_start_idx; Type: INDEX; Schema: acct10001; Owner: postgres
+-- Name: usage_start_idx; Type: INDEX; Schema: acct10001; Owner: kokuadmin
 --
 
 CREATE INDEX usage_start_idx ON acct10001.reporting_awscostentrylineitem_daily USING btree (usage_start);
 
 
 --
--- Name: api_customer_account_id_206bec02_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_customer_account_id_206bec02_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_customer_account_id_206bec02_like ON public.api_customer USING btree (account_id varchar_pattern_ops);
 
 
 --
--- Name: api_customer_schema_name_6b716c4b_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_customer_schema_name_6b716c4b_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_customer_schema_name_6b716c4b_like ON public.api_customer USING btree (schema_name text_pattern_ops);
 
 
 --
--- Name: api_provider_authentication_id_201fd4b9; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_provider_authentication_id_201fd4b9; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_provider_authentication_id_201fd4b9 ON public.api_provider USING btree (authentication_id);
 
 
 --
--- Name: api_provider_billing_source_id_cb6b5a6f; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_provider_billing_source_id_cb6b5a6f; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_provider_billing_source_id_cb6b5a6f ON public.api_provider USING btree (billing_source_id);
 
 
 --
--- Name: api_provider_created_by_id_e740fc35; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_provider_created_by_id_e740fc35; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_provider_created_by_id_e740fc35 ON public.api_provider USING btree (created_by_id);
 
 
 --
--- Name: api_provider_customer_id_87062290; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_provider_customer_id_87062290; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_provider_customer_id_87062290 ON public.api_provider USING btree (customer_id);
 
 
 --
--- Name: api_providerauthentication_provider_resource_name_fa7deecb_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_providerauthentication_provider_resource_name_fa7deecb_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_providerauthentication_provider_resource_name_fa7deecb_like ON public.api_providerauthentication USING btree (provider_resource_name text_pattern_ops);
 
 
 --
--- Name: api_tenant_schema_name_733d339b_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_tenant_schema_name_733d339b_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_tenant_schema_name_733d339b_like ON public.api_tenant USING btree (schema_name varchar_pattern_ops);
 
 
 --
--- Name: api_user_customer_id_90bd21ef; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_user_customer_id_90bd21ef; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_user_customer_id_90bd21ef ON public.api_user USING btree (customer_id);
 
 
 --
--- Name: api_user_username_cf4e88d2_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_user_username_cf4e88d2_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_user_username_cf4e88d2_like ON public.api_user USING btree (username varchar_pattern_ops);
 
 
 --
--- Name: api_userpreference_user_id_e62eaffa; Type: INDEX; Schema: public; Owner: postgres
+-- Name: api_userpreference_user_id_e62eaffa; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX api_userpreference_user_id_e62eaffa ON public.api_userpreference USING btree (user_id);
 
 
 --
--- Name: auth_group_name_a6ea08ec_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_group_name_a6ea08ec_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_group_name_a6ea08ec_like ON public.auth_group USING btree (name varchar_pattern_ops);
 
 
 --
--- Name: auth_group_permissions_group_id_b120cbf9; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_group_permissions_group_id_b120cbf9; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_group_permissions_group_id_b120cbf9 ON public.auth_group_permissions USING btree (group_id);
 
 
 --
--- Name: auth_group_permissions_permission_id_84c5c92e; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_group_permissions_permission_id_84c5c92e; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_group_permissions_permission_id_84c5c92e ON public.auth_group_permissions USING btree (permission_id);
 
 
 --
--- Name: auth_permission_content_type_id_2f476e4b; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_permission_content_type_id_2f476e4b; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_permission_content_type_id_2f476e4b ON public.auth_permission USING btree (content_type_id);
 
 
 --
--- Name: auth_user_groups_group_id_97559544; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_user_groups_group_id_97559544; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_user_groups_group_id_97559544 ON public.auth_user_groups USING btree (group_id);
 
 
 --
--- Name: auth_user_groups_user_id_6a12ed8b; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_user_groups_user_id_6a12ed8b; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_user_groups_user_id_6a12ed8b ON public.auth_user_groups USING btree (user_id);
 
 
 --
--- Name: auth_user_user_permissions_permission_id_1fbb5f2c; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions_permission_id_1fbb5f2c; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_user_user_permissions_permission_id_1fbb5f2c ON public.auth_user_user_permissions USING btree (permission_id);
 
 
 --
--- Name: auth_user_user_permissions_user_id_a95ead1b; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions_user_id_a95ead1b; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_user_user_permissions_user_id_a95ead1b ON public.auth_user_user_permissions USING btree (user_id);
 
 
 --
--- Name: auth_user_username_6821ab7c_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: auth_user_username_6821ab7c_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX auth_user_username_6821ab7c_like ON public.auth_user USING btree (username varchar_pattern_ops);
 
 
 --
--- Name: django_admin_log_content_type_id_c4bce8eb; Type: INDEX; Schema: public; Owner: postgres
+-- Name: django_admin_log_content_type_id_c4bce8eb; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX django_admin_log_content_type_id_c4bce8eb ON public.django_admin_log USING btree (content_type_id);
 
 
 --
--- Name: django_admin_log_user_id_c564eba6; Type: INDEX; Schema: public; Owner: postgres
+-- Name: django_admin_log_user_id_c564eba6; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX django_admin_log_user_id_c564eba6 ON public.django_admin_log USING btree (user_id);
 
 
 --
--- Name: django_session_expire_date_a5c62663; Type: INDEX; Schema: public; Owner: postgres
+-- Name: django_session_expire_date_a5c62663; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX django_session_expire_date_a5c62663 ON public.django_session USING btree (expire_date);
 
 
 --
--- Name: django_session_session_key_c0390e0f_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: django_session_session_key_c0390e0f_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX django_session_session_key_c0390e0f_like ON public.django_session USING btree (session_key varchar_pattern_ops);
 
 
 --
--- Name: region_mapping_region_9c0d71ba_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: region_mapping_region_9c0d71ba_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX region_mapping_region_9c0d71ba_like ON public.region_mapping USING btree (region varchar_pattern_ops);
 
 
 --
--- Name: region_mapping_region_name_ad295b89_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: region_mapping_region_name_ad295b89_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX region_mapping_region_name_ad295b89_like ON public.region_mapping USING btree (region_name varchar_pattern_ops);
 
 
 --
--- Name: reporting_common_costusa_assembly_id_d8da4b1c_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: reporting_common_costusa_assembly_id_d8da4b1c_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_common_costusa_assembly_id_d8da4b1c_like ON public.reporting_common_costusagereportmanifest USING btree (assembly_id text_pattern_ops);
 
 
 --
--- Name: reporting_common_costusa_report_name_134674b5_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: reporting_common_costusa_report_name_134674b5_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_common_costusa_report_name_134674b5_like ON public.reporting_common_costusagereportstatus USING btree (report_name varchar_pattern_ops);
 
 
 --
--- Name: reporting_common_costusagereportmanifest_provider_id_6abb15de; Type: INDEX; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest_provider_id_6abb15de; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_common_costusagereportmanifest_provider_id_6abb15de ON public.reporting_common_costusagereportmanifest USING btree (provider_id);
 
 
 --
--- Name: reporting_common_costusagereportstatus_manifest_id_62ef64b9; Type: INDEX; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus_manifest_id_62ef64b9; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_common_costusagereportstatus_manifest_id_62ef64b9 ON public.reporting_common_costusagereportstatus USING btree (manifest_id);
 
 
 --
--- Name: reporting_common_reportc_provider_column_name_e01eaba3_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: reporting_common_reportc_provider_column_name_e01eaba3_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX reporting_common_reportc_provider_column_name_e01eaba3_like ON public.reporting_common_reportcolumnmap USING btree (provider_column_name varchar_pattern_ops);
 
 
 --
--- Name: si_unit_scale_prefix_eb9daade_like; Type: INDEX; Schema: public; Owner: postgres
+-- Name: si_unit_scale_prefix_eb9daade_like; Type: INDEX; Schema: public; Owner: kokuadmin
 --
 
 CREATE INDEX si_unit_scale_prefix_eb9daade_like ON public.si_unit_scale USING btree (prefix varchar_pattern_ops);
 
 
 --
--- Name: reporting_awscostentrylineitem_daily_summary reporting_awscostent_account_alias_id_684d6c01_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily_summary reporting_awscostent_account_alias_id_684d6c01_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily_summary
@@ -4012,7 +4187,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily_summary
 
 
 --
--- Name: reporting_awscostentrylineitem_aggregates reporting_awscostent_account_alias_id_f97d76e5_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_aggregates reporting_awscostent_account_alias_id_f97d76e5_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_aggregates
@@ -4020,7 +4195,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_aggregates
 
 
 --
--- Name: reporting_awscostentry reporting_awscostent_bill_id_017f27a3_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentry reporting_awscostent_bill_id_017f27a3_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentry
@@ -4028,7 +4203,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentry
 
 
 --
--- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_bill_id_5ae74e09_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_bill_id_5ae74e09_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
@@ -4036,7 +4211,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
 
 
 --
--- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_id_4d1a7fc4_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_id_4d1a7fc4_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
@@ -4044,7 +4219,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
 
 
 --
--- Name: reporting_awscostentrylineitem_daily reporting_awscostent_cost_entry_pricing_i_5a6a9b38_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily reporting_awscostent_cost_entry_pricing_i_5a6a9b38_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily
@@ -4052,7 +4227,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily
 
 
 --
--- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_pricing_i_a654a7e3_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_pricing_i_a654a7e3_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
@@ -4060,7 +4235,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
 
 
 --
--- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_product_i_29c80210_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_product_i_29c80210_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
@@ -4068,7 +4243,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
 
 
 --
--- Name: reporting_awscostentrylineitem_daily reporting_awscostent_cost_entry_product_i_4d8ef2fd_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily reporting_awscostent_cost_entry_product_i_4d8ef2fd_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily
@@ -4076,7 +4251,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily
 
 
 --
--- Name: reporting_awscostentrylineitem_daily reporting_awscostent_cost_entry_reservati_13b1cb08_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem_daily reporting_awscostent_cost_entry_reservati_13b1cb08_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily
@@ -4084,7 +4259,7 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem_daily
 
 
 --
--- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_reservati_9332b371_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_awscostentrylineitem reporting_awscostent_cost_entry_reservati_9332b371_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
@@ -4092,7 +4267,15 @@ ALTER TABLE ONLY acct10001.reporting_awscostentrylineitem
 
 
 --
--- Name: reporting_ocpusagelineitem reporting_ocpusageli_report_id_32a973b0_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpawscostlineitem_daily_summary reporting_ocpawscost_account_alias_id_f19d2883_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
+--
+
+ALTER TABLE ONLY acct10001.reporting_ocpawscostlineitem_daily_summary
+    ADD CONSTRAINT reporting_ocpawscost_account_alias_id_f19d2883_fk_reporting FOREIGN KEY (account_alias_id) REFERENCES acct10001.reporting_awsaccountalias(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: reporting_ocpusagelineitem reporting_ocpusageli_report_id_32a973b0_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem
@@ -4100,7 +4283,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem
 
 
 --
--- Name: reporting_ocpusagelineitem reporting_ocpusageli_report_period_id_be7fa5ad_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagelineitem reporting_ocpusageli_report_period_id_be7fa5ad_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem
@@ -4108,7 +4291,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagelineitem
 
 
 --
--- Name: reporting_ocpusagereport reporting_ocpusagere_report_period_id_477508c6_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: postgres
+-- Name: reporting_ocpusagereport reporting_ocpusagere_report_period_id_477508c6_fk_reporting; Type: FK CONSTRAINT; Schema: acct10001; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY acct10001.reporting_ocpusagereport
@@ -4116,7 +4299,7 @@ ALTER TABLE ONLY acct10001.reporting_ocpusagereport
 
 
 --
--- Name: api_provider api_provider_authentication_id_201fd4b9_fk_api_provi; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_provider api_provider_authentication_id_201fd4b9_fk_api_provi; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_provider
@@ -4124,7 +4307,7 @@ ALTER TABLE ONLY public.api_provider
 
 
 --
--- Name: api_provider api_provider_billing_source_id_cb6b5a6f_fk_api_provi; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_provider api_provider_billing_source_id_cb6b5a6f_fk_api_provi; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_provider
@@ -4132,7 +4315,7 @@ ALTER TABLE ONLY public.api_provider
 
 
 --
--- Name: api_provider api_provider_created_by_id_e740fc35_fk_api_user_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_provider api_provider_created_by_id_e740fc35_fk_api_user_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_provider
@@ -4140,7 +4323,7 @@ ALTER TABLE ONLY public.api_provider
 
 
 --
--- Name: api_provider api_provider_customer_id_87062290_fk_api_customer_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_provider api_provider_customer_id_87062290_fk_api_customer_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_provider
@@ -4148,7 +4331,7 @@ ALTER TABLE ONLY public.api_provider
 
 
 --
--- Name: api_user api_user_customer_id_90bd21ef_fk_api_customer_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_user api_user_customer_id_90bd21ef_fk_api_customer_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_user
@@ -4156,7 +4339,7 @@ ALTER TABLE ONLY public.api_user
 
 
 --
--- Name: api_userpreference api_userpreference_user_id_e62eaffa_fk_api_user_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: api_userpreference api_userpreference_user_id_e62eaffa_fk_api_user_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.api_userpreference
@@ -4164,7 +4347,7 @@ ALTER TABLE ONLY public.api_userpreference
 
 
 --
--- Name: auth_group_permissions auth_group_permissio_permission_id_84c5c92e_fk_auth_perm; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_group_permissions auth_group_permissio_permission_id_84c5c92e_fk_auth_perm; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_group_permissions
@@ -4172,7 +4355,7 @@ ALTER TABLE ONLY public.auth_group_permissions
 
 
 --
--- Name: auth_group_permissions auth_group_permissions_group_id_b120cbf9_fk_auth_group_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_group_permissions auth_group_permissions_group_id_b120cbf9_fk_auth_group_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_group_permissions
@@ -4180,7 +4363,7 @@ ALTER TABLE ONLY public.auth_group_permissions
 
 
 --
--- Name: auth_permission auth_permission_content_type_id_2f476e4b_fk_django_co; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_permission auth_permission_content_type_id_2f476e4b_fk_django_co; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_permission
@@ -4188,7 +4371,7 @@ ALTER TABLE ONLY public.auth_permission
 
 
 --
--- Name: auth_user_groups auth_user_groups_group_id_97559544_fk_auth_group_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user_groups auth_user_groups_group_id_97559544_fk_auth_group_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_groups
@@ -4196,7 +4379,7 @@ ALTER TABLE ONLY public.auth_user_groups
 
 
 --
--- Name: auth_user_groups auth_user_groups_user_id_6a12ed8b_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user_groups auth_user_groups_user_id_6a12ed8b_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_groups
@@ -4204,7 +4387,7 @@ ALTER TABLE ONLY public.auth_user_groups
 
 
 --
--- Name: auth_user_user_permissions auth_user_user_permi_permission_id_1fbb5f2c_fk_auth_perm; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions auth_user_user_permi_permission_id_1fbb5f2c_fk_auth_perm; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_user_permissions
@@ -4212,7 +4395,7 @@ ALTER TABLE ONLY public.auth_user_user_permissions
 
 
 --
--- Name: auth_user_user_permissions auth_user_user_permissions_user_id_a95ead1b_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: auth_user_user_permissions auth_user_user_permissions_user_id_a95ead1b_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.auth_user_user_permissions
@@ -4220,7 +4403,7 @@ ALTER TABLE ONLY public.auth_user_user_permissions
 
 
 --
--- Name: django_admin_log django_admin_log_content_type_id_c4bce8eb_fk_django_co; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: django_admin_log django_admin_log_content_type_id_c4bce8eb_fk_django_co; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_admin_log
@@ -4228,7 +4411,7 @@ ALTER TABLE ONLY public.django_admin_log
 
 
 --
--- Name: django_admin_log django_admin_log_user_id_c564eba6_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: django_admin_log django_admin_log_user_id_c564eba6_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.django_admin_log
@@ -4236,7 +4419,7 @@ ALTER TABLE ONLY public.django_admin_log
 
 
 --
--- Name: reporting_common_costusagereportstatus reporting_common_cos_manifest_id_62ef64b9_fk_reporting; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportstatus reporting_common_cos_manifest_id_62ef64b9_fk_reporting; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_costusagereportstatus
@@ -4244,7 +4427,7 @@ ALTER TABLE ONLY public.reporting_common_costusagereportstatus
 
 
 --
--- Name: reporting_common_costusagereportmanifest reporting_common_cos_provider_id_6abb15de_fk_api_provi; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: reporting_common_costusagereportmanifest reporting_common_cos_provider_id_6abb15de_fk_api_provi; Type: FK CONSTRAINT; Schema: public; Owner: kokuadmin
 --
 
 ALTER TABLE ONLY public.reporting_common_costusagereportmanifest


### PR DESCRIPTION
## Summary

This is the summary table update for OCP on AWS using our initial simple CPU based cost calculation. 

## Testing
Ran nise for OCP and AWS data using static files with the same resource_id. Then downloaded and ran the updater and confirmed that the summary table is populated.