### PR TITLE
Fix case where summarization blows up on missing data

### DIFF
--- a/masu/database/aws_report_db_accessor.py
+++ b/masu/database/aws_report_db_accessor.py
@@ -208,11 +208,15 @@ class AWSReportDBAccessor(ReportDBAccessorBase):
             'masu.database',
             'sql/reporting_awscostentrylineitem_daily.sql'
         )
+        bill_id_where_clause = ''
+        if bill_ids:
+            ids = ','.join(bill_ids)
+            bill_id_where_clause = f'AND cost_entry_bill_id IN ({ids})'
         daily_sql = daily_sql.decode('utf-8').format(
             uuid=str(uuid.uuid4()).replace('-', '_'),
             start_date=start_date,
             end_date=end_date,
-            cost_entry_bill_ids=','.join(bill_ids)
+            bill_id_where_clause=bill_id_where_clause
         )
         self._commit_and_vacuum(table_name, daily_sql, start_date, end_date)
 
@@ -233,11 +237,15 @@ class AWSReportDBAccessor(ReportDBAccessorBase):
             'masu.database',
             'sql/reporting_awscostentrylineitem_daily_summary.sql'
         )
+        bill_id_where_clause = ''
+        if bill_ids:
+            ids = ','.join(bill_ids)
+            bill_id_where_clause = f'AND cost_entry_bill_id IN ({ids})'
         summary_sql = summary_sql.decode('utf-8').format(
             uuid=str(uuid.uuid4()).replace('-', '_'),
             start_date=start_date,
             end_date=end_date,
-            cost_entry_bill_ids=','.join(bill_ids)
+            bill_id_where_clause=bill_id_where_clause
         )
         self._commit_and_vacuum(table_name, summary_sql, start_date, end_date)
 

--- a/masu/database/sql/reporting_awscostentrylineitem_daily.sql
+++ b/masu/database/sql/reporting_awscostentrylineitem_daily.sql
@@ -44,7 +44,7 @@ CREATE TEMPORARY TABLE aws_tag_summary_{uuid} AS (
                 ON li.cost_entry_id = ce.id
             WHERE date(ce.interval_start) >= '{start_date}'
                 AND date(ce.interval_start) <= '{end_date}'
-                AND li.cost_entry_bill_id IN ({cost_entry_bill_ids})
+                {bill_id_where_clause}
         ) li,
         jsonb_each_text(li.tags) tags
     ) t
@@ -102,7 +102,7 @@ CREATE TEMPORARY TABLE reporting_awscostentrylineitem_daily_{uuid} AS (
             ON li.cost_entry_id = ce.id
         WHERE date(ce.interval_start) >= '{start_date}'
             AND date(ce.interval_start) <= '{end_date}'
-            AND li.cost_entry_bill_id IN ({cost_entry_bill_ids})
+            {bill_id_where_clause}
         GROUP BY date(ce.interval_start),
             li.cost_entry_bill_id,
             li.cost_entry_product_id,
@@ -171,10 +171,10 @@ CREATE TEMPORARY TABLE reporting_awscostentrylineitem_daily_{uuid} AS (
 ;
 
 -- Clear out old entries first
-DELETE FROM reporting_awscostentrylineitem_daily
-WHERE usage_start >= '{start_date}'
-    AND usage_start <= '{end_date}'
-    AND cost_entry_bill_id IN ({cost_entry_bill_ids})
+DELETE FROM reporting_awscostentrylineitem_daily AS li
+WHERE li.usage_start >= '{start_date}'
+    AND li.usage_start <= '{end_date}'
+    {bill_id_where_clause}
 ;
 
 -- Populate the daily aggregate line item data

--- a/masu/database/sql/reporting_awscostentrylineitem_daily_summary.sql
+++ b/masu/database/sql/reporting_awscostentrylineitem_daily_summary.sql
@@ -43,7 +43,7 @@ CREATE TEMPORARY TABLE aws_tag_summary_{uuid} AS (
             ON li.cost_entry_pricing_id = pr.id
         WHERE date(li.usage_start) >= '{start_date}'
             AND date(li.usage_start) <= '{end_date}'
-            AND li.cost_entry_bill_id IN ({cost_entry_bill_ids})
+            {bill_id_where_clause}
         GROUP BY li.cost_entry_bill_id,
             li.usage_start,
             li.usage_end,
@@ -109,7 +109,7 @@ CREATE TEMPORARY TABLE reporting_awscostentrylineitem_daily_summary_{uuid} AS (
             ON li.usage_account_id = aa.account_id
         WHERE date(li.usage_start) >= '{start_date}'
             AND date(li.usage_start) <= '{end_date}'
-            AND li.cost_entry_bill_id IN ({cost_entry_bill_ids})
+            {bill_id_where_clause}
         GROUP BY li.cost_entry_bill_id,
             li.usage_start,
             li.usage_end,
@@ -159,10 +159,10 @@ CREATE TEMPORARY TABLE reporting_awscostentrylineitem_daily_summary_{uuid} AS (
 ;
 
 -- -- Clear out old entries first
-DELETE FROM reporting_awscostentrylineitem_daily_summary
-WHERE usage_start >= '{start_date}'
-    AND usage_start <= '{end_date}'
-    AND cost_entry_bill_id IN ({cost_entry_bill_ids})
+DELETE FROM reporting_awscostentrylineitem_daily_summary AS li
+WHERE li.usage_start >= '{start_date}'
+    AND li.usage_start <= '{end_date}'
+    {bill_id_where_clause}
 ;
 
 -- Populate the daily aggregate line item data

--- a/masu/processor/tasks.py
+++ b/masu/processor/tasks.py
@@ -199,11 +199,13 @@ def update_summary_tables(schema_name, provider, provider_uuid, start_date, end_
     stmt = ('update_summary_tables called with args:\n'
             ' schema_name: {},\n'
             ' provider: {},\n'
+            ' provider_uuid {},\n'
             ' start_date: {},\n'
             ' end_date: {},\n'
             ' manifest_id: {}')
     stmt = stmt.format(schema_name,
                        provider,
+                       provider_uuid,
                        start_date,
                        end_date,
                        manifest_id)


### PR DESCRIPTION
## Summary
This makes a WHERE clause expecting bill_ids to be fully optional so that the SQL does not blow up with a syntax error looking for `bill_id IN ()`. This shouldn't be a case that happens in the normal business flow, but when running the report data summary API it triggers AWS providers with no data and blows up.